### PR TITLE
PIL hasn't been maintained since 2005

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -4,7 +4,7 @@ MySQL-python
 lxml
 pymarc
 solrpy
-PIL
+Pillow
 simplejson
 feedparser
 rfc3339==5


### PR DESCRIPTION
Pillow is its friendly fork: https://python-pillow.github.io/
Had to move to Pillow because PIL is no longer readily available through pip
This has not been tested much at all but open-ONI won't install without it
and basic image tiling seems to be working