### PR TITLE
Fix logging format strings

### DIFF
--- a/core/views/image.py
+++ b/core/views/image.py
@@ -22,15 +22,17 @@ if settings.USE_TIFF:
     from PIL import Image
 else:
     import NativeImaging
+
     for backend in ('aware_cext', 'aware', 'graphicsmagick'):
         try:
             Image = NativeImaging.get_image_class(backend)
+            LOGGER.info("Using NativeImage backend '%s'", backend)
             break
         except ImportError, e:
-            LOGGER.info("NativeImage backend '%s' not available.")
+            LOGGER.info("NativeImage backend '%s' not available.", backend)
     else:
         raise Exception("No suitable NativeImage backend found.")
-    LOGGER.info("Using NativeImage backend '%s'" % backend)
+
 
 
 def _get_image(page):


### PR DESCRIPTION
* Actually pass the backend value to NativeImaging fallback logging
* Avoid forcing evaluation of log messages