### PR TITLE
Requirements: use compatible versions of Celery & Kombu

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -12,8 +12,9 @@ NativeImaging==0.0.7
 html5lib==0.95
 rdflib==3.2.3
 requests==2.9.1
-django-celery==3.1.17
+django-celery<4
+Celery<4
+kombu<4
 django-kombu==0.9.4
 worldcat==0.3.6
-
 


### PR DESCRIPTION
Until the migration away from the deprecated `django-celery` package is
complete, using the current 4.x versions of Celery and Kombu will cause
various errors on startup as @johnscancella recently discovered.