### PR TITLE
Forms: cache title & full-text range data using metadata TTL

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -59,7 +59,7 @@ def _titles_states():
         for state in _states:
             states.append((state, state))
         states = sorted(states)
-        cache.set("titles_states", (titles, states))
+        cache.set("titles_states", (titles, states), settings.METADATA_TTL_SECONDS)
     else:
         titles, states = titles_states
     return (titles, states)
@@ -91,7 +91,7 @@ def _fulltext_range():
         #max_year = min(max_year, MAX_YEAR)
 
         fulltext_range = (min_year, max_year)
-        cache.set('fulltext_range', fulltext_range)
+        cache.set('fulltext_range', fulltext_range, settings.METADATA_TTL_SECONDS)
     return fulltext_range
 
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,10 +1,10 @@
 import datetime
 
 from django import forms
-from django.forms import fields
 from django.conf import settings
 from django.core.cache import cache
-from django.db.models import Min, Max
+from django.db.models import Max, Min
+from django.forms import fields
 
 from chronam.core import models
 
@@ -39,7 +39,7 @@ def _titles_states():
     returns a tuple of two elements (list of titles, list of states)
 
     example return value:
-    ([('', 'All newspapers'), (u'sn83030214', u'New-York tribune. (New York [N.Y.])')], 
+    ([('', 'All newspapers'), (u'sn83030214', u'New-York tribune. (New York [N.Y.])')],
      [('', 'All states'), (u'New York', u'New York')])
     """
     titles_states = cache.get("titles_states")

--- a/settings_template.py
+++ b/settings_template.py
@@ -117,6 +117,8 @@ BROKER_URL = 'django://'
 THUMBNAIL_WIDTH = 360
 
 DEFAULT_TTL_SECONDS = 86400  # 1 day
+#: Used to cache metadata about publishers, issues, etc. as distinct from HTML pages, images, search results, etc.
+METADATA_TTL_SECONDS = DEFAULT_TTL_SECONDS
 PAGE_IMAGE_TTL_SECONDS = 60 * 60 * 24 * 7 * 2  # 2 weeks
 API_TTL_SECONDS = 60 * 60  # 1 hour
 FEED_TTL_SECONDS = 60 * 60 * 24 * 7

--- a/settings_template.py
+++ b/settings_template.py
@@ -31,13 +31,13 @@ DATABASES = {
         'NAME': 'chronam',
         'USER': 'chronam',
         'PASSWORD': 'pick_one',
-        }
     }
+}
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'px2@!q2(m5alb$0=)h@u*80mmf9cd-nn**^y4j2j&+_8h^n_0f'
 
-#persist the database connections instead of closing after each request
+# persist the database connections instead of closing after each request
 CONN_MAX_AGE = None
 
 LOGGING = {
@@ -57,7 +57,7 @@ LOGGING = {
             'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'verbose',
             'filename': '/var/log/httpd/chronam.log',
-            'maxBytes': 1024*1024*50, #50MB
+            'maxBytes': 1024 * 1024 * 50,  # 50MB
             'backupCount': 5,
         },
     },
@@ -75,7 +75,7 @@ LOGGING = {
     },
     'root': {
         'handlers': ['file'],
-            'level': 'DEBUG'
+        'level': 'DEBUG'
     },
 }
 
@@ -98,7 +98,7 @@ TEMPLATES = [
                 'chronam.core.context_processors.extra_request_info',
                 'chronam.core.context_processors.newspaper_info',
             ],
-            'debug' : DEBUG,
+            'debug': DEBUG,
         },
     },
 ]
@@ -130,7 +130,7 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
         'LOCATION': '/var/tmp/django_cache',
-        'TIMEOUT': 4838400, # 2 months
+        'TIMEOUT': 4838400,  # 2 months
     }
 }
 
@@ -148,7 +148,7 @@ SENDFILE_BACKEND = 'sendfile.backends.xsendfile'
 
 import multiprocessing
 TOO_BUSY_LOAD_AVERAGE = 1.5 * multiprocessing.cpu_count()
-#TOO_BUSY_LOAD_AVERAGE = 64 
+#TOO_BUSY_LOAD_AVERAGE = 64
 
 SOLR = "http://localhost:8983/solr"
 SOLR_LANGUAGES = ("eng", "fre", "spa", "ger", "ita",)
@@ -160,7 +160,7 @@ OCR_DUMP_STORAGE = os.path.join(STORAGE, "ocr")
 COORD_STORAGE = os.path.join(STORAGE, "word_coordinates")
 
 
-BASE_CRUMBS = [{'label':'Home', 'href': '/'}]
+BASE_CRUMBS = [{'label': 'Home', 'href': '/'}]
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts


### PR DESCRIPTION
This data was being cached for what was configured by default as a two month
expiration. This changes these two lists used by form inputs to use
METADATA_TTL_SECONDS which is by default one day.