### PR TITLE
Use METADATA_TTL_SECONDS for newspaper_info context processor

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -56,6 +56,6 @@ def newspaper_info(request):
                 'ethnicities_with_issues': ethnicities_with_issues,
                 'total_page_count': total_page_count}
 
-        cache.set("newspaper_info", info)
+        cache.set("newspaper_info", info, settings.METADATA_TTL_SECONDS)
 
     return info


### PR DESCRIPTION
This parallels #163 and uses `METADATA_TTL_SECONDS` for the newspaper information context processor's data as well.