### PR TITLE
Add resource hints

### DIFF
--- a/loc/templates/base.html
+++ b/loc/templates/base.html
@@ -16,6 +16,7 @@
           href="http://www.loc.gov/rss/ndnp/ndnp.xml" />
     <meta http-equiv="Content-Language" content="en-us" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <link rel="preconnect" href="//cdn.loc.gov">
     <link type="text/css" rel="stylesheet" href="{% static 'base.css' %}" />
     <link type="text/css" rel="stylesheet"
           href="{% static 'jquery-ui.css' %}" />

--- a/loc/templates/home.html
+++ b/loc/templates/home.html
@@ -3,6 +3,12 @@
 {% load static from staticfiles %}
 {% load humanize %}
  
+
+{% block extrahead %}
+    <link rel="preload" as="html" href="/tabs">
+    {{ block.super }}
+{% endblock extrahead %}
+
 {% block javascript %}
 {{ block.super }}
 <!-- jCarousel --> 


### PR DESCRIPTION
This makes adds two [resource hints](https://w3c.github.io/resource-hints/) to trigger connection to the CDN server faster and to warm the cache for the homepage tabs. 

Browser support:
* http://caniuse.com/#feat=link-rel-prefetch
* http://caniuse.com/#feat=link-rel-preconnect