### PR TITLE
CHRONAM-331 Fix Title indexing errors in Chronicling America

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -280,6 +280,9 @@ class Title(models.Model):
 
     @property
     def solr_doc(self):
+        language = [l.name for l in self.languages.all()]
+        if not language:
+            language = ['English']
         doc = {
             'id': self.url,
             'type': 'title',
@@ -292,7 +295,7 @@ class Title(models.Model):
             'publisher': self.publisher,
             'start_year': self.start_year_int,
             'end_year': self.end_year_int,
-            'language': [l.name for l in self.languages.all()],
+            'language': language,
             'alt_title': [t.name for t in self.alt_titles.all()],
             'subject': [s.heading for s in self.subjects.all()],
             'note': [n.text for n in self.notes.all()],

--- a/core/models.py
+++ b/core/models.py
@@ -280,9 +280,9 @@ class Title(models.Model):
 
     @property
     def solr_doc(self):
-        language = [l.name for l in self.languages.all()]
-        if not language:
-            language = ['English']
+        languages = [l.name for l in self.languages.all()]
+        if not languages:
+            languages = ['English']
         doc = {
             'id': self.url,
             'type': 'title',
@@ -295,7 +295,7 @@ class Title(models.Model):
             'publisher': self.publisher,
             'start_year': self.start_year_int,
             'end_year': self.end_year_int,
-            'language': language,
+            'language': languages,
             'alt_title': [t.name for t in self.alt_titles.all()],
             'subject': [s.heading for s in self.subjects.all()],
             'note': [n.text for n in self.notes.all()],


### PR DESCRIPTION
CHRONAM-331 Fix Title indexing errors in Chronicling America/
Added code to core/models.py that takes care of empty language list.
Manually tested 1. django-admin pull-titles 2. django-admin index_titles for batches 2016212427 and 
 2016212406 
The error in index_titles.log was gone 