### PR TITLE
Fixing bugs / LanguageText should be populated along with other tables

### DIFF
--- a/core/batch_loader.py
+++ b/core/batch_loader.py
@@ -435,6 +435,7 @@ class BatchLoader(object):
             except models.Language.DoesNotExist:
                 # default to english as per requirement
                 language = models.Language.objects.get(code='eng')
+            ocr.language_texts.create(language=language)
             lang_text_solr[language.code] = text
 
         page.ocr = ocr


### PR DESCRIPTION
@myusuf @acdha @johnscancella 
Fixing bugs / LanguageText should be populated along with other
tables, otherwise http://chroniclingamerica.loc.gov/languages/
will always be empty