### PR TITLE
Remove coordinate reprocessing code

### DIFF
--- a/core/decorator.py
+++ b/core/decorator.py
@@ -2,6 +2,7 @@ import hotshot
 import os
 import re
 import time
+from functools import wraps
 
 from django.core import urlresolvers
 from django.http import HttpResponse
@@ -89,6 +90,8 @@ def cors(f, *args, **kwargs):
     developers to use our JSON in their JavaScript applications without
     forcing them to proxy it.
     """
+
+    @wraps(f)
     def new_f(*args, **kwargs):
         response = f(*args, **kwargs)
         response['Access-Control-Allow-Origin'] = '*'

--- a/core/decorator.py
+++ b/core/decorator.py
@@ -1,14 +1,12 @@
+import hotshot
 import os
 import re
 import time
-import hotshot
 
-from mimeparse import best_match
-
-from django.utils import cache
-from django.utils import encoding
-from django.http import HttpResponse
 from django.core import urlresolvers
+from django.http import HttpResponse
+from django.utils import cache, encoding
+from mimeparse import best_match
 
 
 class HttpResponseSeeOther(HttpResponse):
@@ -58,7 +56,7 @@ def rdf_view(f):
             response['Vary'] = 'Accept'
             return response
         elif match == 'text/html':
-            return html_redirect 
+            return html_redirect
         else:
             return HttpResponseUnsupportedMediaType()
     return f1
@@ -67,10 +65,10 @@ def opensearch_clean(f):
     """
     Some opensearch clients send along optional parameters from the opensearch
     description when they're not needed. For example:
-    
+
         state={chronam:state?}
 
-    These can cause search results not to come back, and even can cause Solr's 
+    These can cause search results not to come back, and even can cause Solr's
     query parsing to throw an exception, so it's best to remove them when
     present.
     """
@@ -85,7 +83,7 @@ def opensearch_clean(f):
 
 def cors(f, *args, **kwargs):
     """
-    Adds CORS header to allow a response to be loaded by JavaScript that 
+    Adds CORS header to allow a response to be loaded by JavaScript that
     may have originated from somewhere other than chroniclingamerica.loc.gov
     which is useful for some API response like AutoSuggest. Basically allows
     developers to use our JSON in their JavaScript applications without
@@ -122,4 +120,3 @@ def profile(log_file):
 
         return _inner
     return _outer
-

--- a/core/views/image.py
+++ b/core/views/image.py
@@ -1,19 +1,20 @@
+from __future__ import absolute_import
+
+import gzip
 import logging
 import os.path
-import urlparse
 import urllib2
 import json
-import gzip
 import re
-
+import urlparse
 from cStringIO import StringIO
 
 from django.conf import settings
 from django.http import Http404, HttpResponse, HttpResponseServerError
 
 from chronam.core import models
-from chronam.core.utils.utils import get_page
 from chronam.core.decorator import cors
+from chronam.core.utils.utils import get_page
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,11 +29,10 @@ else:
             Image = NativeImaging.get_image_class(backend)
             LOGGER.info("Using NativeImage backend '%s'", backend)
             break
-        except ImportError, e:
+        except ImportError as e:
             LOGGER.info("NativeImage backend '%s' not available.", backend)
     else:
         raise Exception("No suitable NativeImage backend found.")
-
 
 
 def _get_image(page):
@@ -47,7 +47,7 @@ def _get_image(page):
     try:
         fp = urllib2.urlopen(url)
         stream = StringIO(fp.read())
-    except IOError, e:
+    except IOError as e:
         e.message += " (while trying to open %s)" % url
         raise e
     im = Image.open(stream)
@@ -57,7 +57,7 @@ def _get_image(page):
 def _get_resized_image(page, width):
     try:
         im = _get_image(page)
-    except IOError, e:
+    except IOError as e:
         return HttpResponseServerError("Unable to create image: %s" % e)
     actual_width, actual_height = im.size
     height = int(round(width / float(actual_width) * float(actual_height)))
@@ -69,7 +69,7 @@ def thumbnail(request, lccn, date, edition, sequence):
     page = get_page(lccn, date, edition, sequence)
     try:
         im = _get_resized_image(page, settings.THUMBNAIL_WIDTH)
-    except IOError, e:
+    except IOError as e:
         return HttpResponseServerError("Unable to create thumbnail: %s" % e)
     response = HttpResponse(content_type="image/jpeg")
     im.save(response, "JPEG")
@@ -80,7 +80,7 @@ def medium(request, lccn, date, edition, sequence):
     page = get_page(lccn, date, edition, sequence)
     try:
         im = _get_resized_image(page, 550)
-    except IOError, e:
+    except IOError as e:
         return HttpResponseServerError("Unable to create thumbnail: %s" % e)
     response = HttpResponse(content_type="image/jpeg")
     im.save(response, "JPEG")
@@ -106,7 +106,7 @@ def page_image_tile(request, lccn, date, edition, sequence,
     x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
     try:
         im = _get_image(page)
-    except IOError, e:
+    except IOError as e:
         return HttpResponseServerError("Unable to create image tile: %s" % e)
 
     width = min(width, (x2-x1))
@@ -129,7 +129,7 @@ def image_tile(request, path, width, height, x1, y1, x2, y2):
     try:
         p = os.path.join(settings.BATCH_STORAGE, path)
         im = Image.open(p)
-    except IOError, e:
+    except IOError as e:
         return HttpResponseServerError("Unable to create image tile: %s" % e)
     c = im.crop((x1, y1, x2, y2))
     f = c.resize((width, height))

--- a/core/views/image.py
+++ b/core/views/image.py
@@ -139,8 +139,11 @@ def image_tile(request, path, width, height, x1, y1, x2, y2):
 def coordinates(request, lccn, date, edition, sequence, words=None):
     url_parts = dict(lccn=lccn, date=date, edition=edition, sequence=sequence)
 
+    file_path = models.coordinates_path(url_parts)
+
     try:
-        with gzip.open(models.coordinates_path(url_parts), 'rb') as i:
+        with gzip.open(file_path, 'rb') as i:
             return HttpResponse(i.read(), content_type='application/json')
     except IOError:
+        LOGGER.warning('Word coordinates file %s does not exist', file_path)
         raise Http404


### PR DESCRIPTION
This was added in an attempt to deal with OCR noise:

https://github.com/LibraryOfCongress/chronam/commit/87d0216fdc88ede6a35fed222d551b1f97d94a8f
 
Unfortunately it also strips non-English text: languages such as Arabic
would be completely removed and non-ASCII characters on the beginning or
end of a line would also be silently stripped.
 
This commit avoids data loss but does it would likely also be necessary to
review the original impetus for this request and see whether we need to
make the JavaScript highlighting code smarter about matching words ignoring
punctuation.

This would be an important step towards landing something like #108 since we
don't want to have a conditional data path which returns different results.