### PR TITLE
Add .editorconfig and prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "prettier": "^1.9.2"
+  }
+}


### PR DESCRIPTION
`.editorconfig` provides default settings which many editors and tools respect (see http://editorconfig.org/)

Prettier can now trivially be installed with NPM and Yarn and, as of https://github.com/prettier/prettier/commit/8f58ca0f4802db62719ef6689bd5fb7c476c7afb, now uses `.editorconfig` to load some of its settings.
  