### PR TITLE
Tidy README formatting for caching section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,42 +145,48 @@ via the Web:
     http://www.example.org/batches/
 
 Caching
---------------
+-------
+
 After loading data, you will need to clear the cache. If you are using a reverse proxie (like Varnish) you will need to also clear that, as well as any CDN you have. Below is a list of URLS that should be cleared based on what content you are loading.
 
 All pages that contain a LCCN are tagged with that LCCN in the cache headers. This allows for purging by specific LCCN tag if there is a update to a batch.
 
-  List of URLs to purge when loading new batch
-  ==============================================
-  all urls tagged with lccn=<LCCN>
-  chroniclingamerica.loc.gov/tabs
-  chroniclingamerica.loc.gov/sitemap*
-  chroniclingamerica.loc.gov/frontpages*
-  chroniclingamerica.loc.gov/titles*
-  chroniclingamerica.loc.gov/states*
-  chroniclingamerica.loc.gov/counties*
-  chroniclingamerica.loc.gov/states_counties*
-  chroniclingamerica.loc.gov/cities*
-  chroniclingamerica.loc.gov/batches/summary*
-  chroniclingamerica.loc.gov/reels*
-  chroniclingamerica.loc.gov/reel*
-  chroniclingamerica.loc.gov/essays*
+List of URLs to purge when loading new batch
+==============================================
+* All URLs tagged with `lccn=<LCCN>`
+* All URLs matching these patterns:
+    ```
+    chroniclingamerica.loc.gov/tabs
+    chroniclingamerica.loc.gov/sitemap*
+    chroniclingamerica.loc.gov/frontpages*
+    chroniclingamerica.loc.gov/titles*
+    chroniclingamerica.loc.gov/states*
+    chroniclingamerica.loc.gov/counties*
+    chroniclingamerica.loc.gov/states_counties*
+    chroniclingamerica.loc.gov/cities*
+    chroniclingamerica.loc.gov/batches/summary*
+    chroniclingamerica.loc.gov/reels*
+    chroniclingamerica.loc.gov/reel*
+    chroniclingamerica.loc.gov/essays*
+    ```
 
-  List of URLs to purge when loading new Awardee
-  ==============================================
-  chroniclingamerica.loc.gov/awardees*
+List of URLs to purge when loading new Awardees
+===============================================
+* All URLs matching `chroniclingamerica.loc.gov/awardees*`
 
-  List of URLs to purge when loading new basic data
-  ==============================================
-  chroniclingamerica.loc.gov/institutions*
+List of URLs to purge when loading new basic data
+=================================================
+* All URLs matching `chroniclingamerica.loc.gov/institutions*`
 
-  List of URLs to purge when loading code
-  ==============================================
-  chroniclingamerica.loc.gov/ocr
-  chroniclingamerica.loc.gov/about
-  chroniclingamerica.loc.gov/about/api
-  chroniclingamerica.loc.gov/help
-
+List of URLs to purge when loading code
+=======================================
+* All URLs matching these patterns:
+    ```
+    chroniclingamerica.loc.gov/ocr
+    chroniclingamerica.loc.gov/about
+    chroniclingamerica.loc.gov/about/api
+    chroniclingamerica.loc.gov/help
+    ```
 
 Run Unit Tests
 --------------

--- a/core/decorator.py
+++ b/core/decorator.py
@@ -4,6 +4,7 @@ import re
 import time
 from functools import wraps
 
+from django.conf import settings
 from django.core import urlresolvers
 from django.http import HttpResponse
 from django.utils import cache, encoding
@@ -67,6 +68,7 @@ def rdf_view(f):
             return HttpResponseUnsupportedMediaType()
     return f1
 
+
 def opensearch_clean(f):
     """
     Some opensearch clients send along optional parameters from the opensearch
@@ -87,6 +89,7 @@ def opensearch_clean(f):
         return f(request, **kwargs)
     return f1
 
+
 def cors(f, *args, **kwargs):
     """
     Adds CORS header to allow a response to be loaded by JavaScript that
@@ -104,10 +107,12 @@ def cors(f, *args, **kwargs):
         return response
     return new_f
 
+
 try:
     PROFILE_LOG_BASE = settings.PROFILE_LOG_BASE
-except:
+except AttributeError:
     PROFILE_LOG_BASE = '/tmp'
+
 
 def profile(log_file):
     if not os.path.isabs(log_file):

--- a/core/decorator.py
+++ b/core/decorator.py
@@ -1,10 +1,6 @@
-import hotshot
-import os
 import re
-import time
 from functools import wraps
 
-from django.conf import settings
 from django.core import urlresolvers
 from django.http import HttpResponse
 from django.utils import cache, encoding
@@ -106,30 +102,3 @@ def cors(f, *args, **kwargs):
         response['Access-Control-Allow-Headers'] = 'X-requested-with'
         return response
     return new_f
-
-
-try:
-    PROFILE_LOG_BASE = settings.PROFILE_LOG_BASE
-except AttributeError:
-    PROFILE_LOG_BASE = '/tmp'
-
-
-def profile(log_file):
-    if not os.path.isabs(log_file):
-        log_file = os.path.join(PROFILE_LOG_BASE, log_file)
-
-    def _outer(f):
-        def _inner(*args, **kwargs):
-            (base, ext) = os.path.splitext(log_file)
-            base = base + "-" + time.strftime("%Y%m%dT%H%M%S", time.gmtime())
-            final_log_file = base + ext
-
-            prof = hotshot.Profile(final_log_file)
-            try:
-                ret = prof.runcall(f, *args, **kwargs)
-            finally:
-                prof.close()
-            return ret
-
-        return _inner
-    return _outer

--- a/core/decorator.py
+++ b/core/decorator.py
@@ -2,7 +2,6 @@ import hotshot
 import os
 import re
 import time
-import functools
 from functools import wraps
 
 from django.core import urlresolvers
@@ -22,11 +21,12 @@ class HttpResponseSeeOther(HttpResponse):
 class HttpResponseUnsupportedMediaType(HttpResponse):
     status_code = 415
 
-#replace with cache_control in django 1.10+
+
+# TODO: replace this with the standard Django 1.10+ cache_control decorator
 def add_cache_headers(ttl, shared_cache_maxage=None):
     """Decorate the provided function by adding Cache-Control and Expires headers to responses"""
     def decorator(function):
-        @functools.wraps(function)
+        @wraps(function)
         def decorated_function(*args, **kwargs):
             response = function(*args, **kwargs)
             cache.patch_response_headers(response, ttl)
@@ -36,6 +36,7 @@ def add_cache_headers(ttl, shared_cache_maxage=None):
         return decorated_function
 
     return decorator
+
 
 def rdf_view(f):
     def f1(request, **kwargs):

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -227,10 +227,11 @@ def page(request, lccn, date, edition, sequence):
                                                      kwargs=path_parts), request.GET.urlencode(), words)
             response = HttpResponseRedirect(url)
             return add_cache_tag(response, "lccn=%s" % lccn)
-    except Exception as e:
-        LOGGER.exception(e)
+    except Exception as exc:
+        LOGGER.error("Failed to add search highlighting based on the referred search engine query: %s",
+                     exc, exc_info=True)
         if settings.DEBUG:
-            raise e
+            raise
         # else squish the exception so the page will still get
         # served up minus the highlights
 

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -437,7 +437,7 @@ def title_essays(request, lccn):
     # if there's only one essay might as well redirect to it
     if len(title.essays.all()) >= 1:
         url = title.essays.all()[0].url
-        return cacne_tag(HttpResponsePermanentRedirect(url), "lccn=%s" % lccn)
+        return add_cache_tag(HttpResponsePermanentRedirect(url), "lccn=%s" % lccn)
     else:
         return HttpResponseNotFound()
 


### PR DESCRIPTION
* Consistent indentation for URL lists
* Mark URL patterns as pre-formatted text to prevent 
  Markdown interpreting the “*” as a bold formatting
  instruction and to make copy-and-paste easier
* Minor copy-editing