### PR TITLE
Update notice regarding regenerated OCR dumps

### DIFF
--- a/core/templates/about_api.html
+++ b/core/templates/about_api.html
@@ -339,6 +339,8 @@ do not want the Chronicling America API as an external dependency.
 
 To support these and other potential use cases we are beginning to provide
 bulk access to the underlying data sets. The initial bulk data sets include:
+</p>
+
 
 <ul>
     <li>Batches: each batch of digitized content that is provided by awardees is
@@ -356,13 +358,23 @@ bulk access to the underlying data sets. The initial bulk data sets include:
     you to build automated workflows for updating your local collection.</li>
 </ul>
 
+<p>
 Please note: Some batches contain digitized newspaper pages that lack corresponding OCR text.  For this reason, after decompressing the downloadable files, the number of ocr.txt files may not match the page count available within the HTML, Atom and JSON batch views.
 </p>
-<p class="backtotop"><a href="#skip_menu">Top</a></p>
 
 <p>
-    <b>Update:</b> OCR Bulk Data download files previously available from the <a href="{% url 'chronam_ocr' %}">OCR</a> report (prior to 6/3/19) are temporarily unavailable while they are being re-generated. Newly generated files will appear marked with date stamps after 6/3/19. OCR files for all newspaper pages currently ingested in Chronicling America are also available for machine-readable access at <a href="https://chroniclingamerica.loc.gov/data/batches/">https://chroniclingamerica.loc.gov/data/batches/</a>. Contact <a href="mailto:ndnptech@loc.gov">ndnptech@loc.gov</a> with any questions.
+    <b>Update (July 2019):</b>
+
+    In early June 2019, an error was identified with the <a href="/data/ocr/">OCR Bulk Data download files</a> available from the <a href="{% url 'chronam_ocr' %}">OCR</a> report.
+    These errors have been corrected but any files downloaded before June 3rd should be replaced with the current versions.
+    The source OCR data for all newspaper pages currently ingested in Chronicling America are also available at
+    <a href="https://chroniclingamerica.loc.gov/data/batches/">https://chroniclingamerica.loc.gov/data/batches/</a>.
+
+    <br>
+    Contact <a href="mailto:ndnptech@loc.gov">ndnptech@loc.gov</a> with any questions.
 </p>
+
+<p class="backtotop"><a href="#skip_menu">Top</a></p>
 
 <a name="cors_jsonp"></a>
 <h3>CORS and JSONP Support</h3>

--- a/core/templates/about_api.html
+++ b/core/templates/about_api.html
@@ -366,7 +366,7 @@ Please note: Some batches contain digitized newspaper pages that lack correspond
     <b>Update (July 2019):</b>
 
     In early June 2019, an error was identified with the <a href="/data/ocr/">OCR Bulk Data download files</a> available from the <a href="{% url 'chronam_ocr' %}">OCR</a> report.
-    These errors have been corrected but any files downloaded before June 3rd should be replaced with the current versions.
+    These errors have been corrected but any files downloaded between February 5th and June 3rd 2019 should be replaced with the current versions.
     The source OCR data for all newspaper pages currently ingested in Chronicling America are also available at
     <a href="https://chroniclingamerica.loc.gov/data/batches/">https://chroniclingamerica.loc.gov/data/batches/</a>.
 

--- a/core/templates/reports/ocr.html
+++ b/core/templates/reports/ocr.html
@@ -60,7 +60,7 @@ Please note: Some batches contain digitized newspaper pages that lack correspond
     <b>Update (July 2019):</b>
 
     In early June 2019, an error was identified with the <a href="/data/ocr/">OCR Bulk Data download files</a> available from the <a href="{% url 'chronam_ocr' %}">OCR</a> report.
-    These errors have been corrected but any files downloaded before June 3rd should be replaced with the current versions.
+    These errors have been corrected but any files downloaded between February 5th and June 3rd 2019 should be replaced with the current versions.
     The source OCR data for all newspaper pages currently ingested in Chronicling America are also available at
     <a href="https://chroniclingamerica.loc.gov/data/batches/">https://chroniclingamerica.loc.gov/data/batches/</a>.
 

--- a/core/templates/reports/ocr.html
+++ b/core/templates/reports/ocr.html
@@ -56,12 +56,16 @@ If you are interested in automated access to this data you may want to use the
 Please note: Some batches contain digitized newspaper pages that lack corresponding OCR text.  For this reason, after decompressing the downloadable files, the number of ocr.txt files may not match the page count available within the HTML, Atom and JSON batch views.
 </p>
 
-
 <p>
-    <b>Update:</b> OCR Bulk Data download files previously available from this page (prior to 6/3/19) are temporarily unavailable while they are being re-generated. Newly generated files appear below and are marked with date stamps after 6/3/19.  Please see <a href="https://chroniclingamerica.loc.gov/about/api/">https://chroniclingamerica.loc.gov/about/api/</a> for information on other ways to harvest OCR files from this site using the API. OCR files for all newspaper pages currently ingested in Chronicling America are also available for machine-readable access at <a href="https://chroniclingamerica.loc.gov/data/batches/">https://chroniclingamerica.loc.gov/data/batches/</a>. Contact <a href="mailto:ndnptech@loc.gov">ndnptech@loc.gov</a> with any questions.
-</p>
+    <b>Update (July 2019):</b>
 
-<p>
+    In early June 2019, an error was identified with the <a href="/data/ocr/">OCR Bulk Data download files</a> available from the <a href="{% url 'chronam_ocr' %}">OCR</a> report.
+    These errors have been corrected but any files downloaded before June 3rd should be replaced with the current versions.
+    The source OCR data for all newspaper pages currently ingested in Chronicling America are also available at
+    <a href="https://chroniclingamerica.loc.gov/data/batches/">https://chroniclingamerica.loc.gov/data/batches/</a>.
+
+    <br>
+    Contact <a href="mailto:ndnptech@loc.gov">ndnptech@loc.gov</a> with any questions.
 </p>
 
 <table class="data table table-striped table-hover">


### PR DESCRIPTION
Since the OCR dumps were regenerated the notice should be changed.

![Screenshot_2019-07-18 About the Site and API « Chronicling America « Library of Congress](https://user-images.githubusercontent.com/46565/61486912-9b658b80-a972-11e9-9ac4-ec4c1ce9f7a8.png)
![Screenshot_2019-07-18 OCR Data « Chronicling America « Library of Congress](https://user-images.githubusercontent.com/46565/61487254-6b6ab800-a973-11e9-8487-6920b126aa74.png)
