### PR TITLE
Redirect images to IIIF

### DIFF
--- a/core/views/image.py
+++ b/core/views/image.py
@@ -133,7 +133,7 @@ def image_tile(request, path, width, height, x1, y1, x2, y2):
 
 @cors
 def coordinates(request, lccn, date, edition, sequence, words=None):
-    url_parts = dict(lccn=lccn, date=date, edition=edition, sequence=sequence)
+    url_parts = {"lccn": lccn, "date": date, "edition": edition, "sequence": sequence}
 
     file_path = models.coordinates_path(url_parts)
 

--- a/loc/templates/page.html
+++ b/loc/templates/page.html
@@ -19,13 +19,6 @@
     <script src="{% static 'vendor/jquery.ba-bbq.min.js' %}"></script>
     <script src="{% static 'js/search.js' %}"></script>
     <script src="{% static 'js/page.js' %}"></script>
-
-    <noscript><!-- without javascript the pageviewer does not work; display OCR in this case instead. -->
-        <h3>Newspaper Page Text</h3>
-        {% if text %}
-        <pre>{{ text|join:" \n\n " |linebreaks }} </pre>
-        {% endif %}
-    </noscript>
 {% endblock javascript %}
 
 {% block lc_metadata %}
@@ -126,6 +119,20 @@
 <span>About <a href="{% url 'chronam_title' title.lccn %}">{{page_head_subheading}}</a></span>
 </h1>
 {% endblock %}
+
+{% block content %}
+    {{ block.super }}
+
+    {% comment %} Without javascript the pageviewer does not work; display OCR in this case instead. {% endcomment %}
+    <noscript>
+        <h3>Newspaper Page Text</h3>
+        {% if text %}
+            <pre>
+                {{ text|join:" \n\n " |linebreaks }}
+            </pre>
+        {% endif %}
+    </noscript>
+{% endblock content %}
 
 {% block subcontent %}
 

--- a/settings_template.py
+++ b/settings_template.py
@@ -20,6 +20,7 @@ USE_L10N = True
 MEDIA_ROOT = ""
 MEDIA_URL = ""
 IIIF_IMAGE_BASE_URL = None
+REDIRECT_IMAGES_TO_IIIF = False
 
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.CachedStaticFilesStorage"
 


### PR DESCRIPTION
Now that we're using IIIF for new URLs, we want to be prepared to issue redirects for the old ones. This change adds a `REDIRECT_IMAGES_TO_IIIF` setting which will issue temporary redirects for the image views.