### PR TITLE
Remove RDF content negotiation

### DIFF
--- a/core/decorator.py
+++ b/core/decorator.py
@@ -40,38 +40,6 @@ def add_cache_headers(ttl, shared_cache_maxage=None):
     return decorator
 
 
-def rdf_view(f):
-    @wraps(f)
-    def f1(request, **kwargs):
-        # construct a http redirect response to html view
-        html_view = f.func_name.replace("_rdf", "")
-        html_url = urlresolvers.reverse("chronam_%s" % html_view, kwargs=kwargs)
-        html_redirect = HttpResponseSeeOther(html_url)
-
-        # determine the clients preferred representation
-        available = ["text/html", "application/rdf+xml"]
-        accept = request.META.get("HTTP_ACCEPT", "application/rdf+xml")
-        match = best_match(available, accept)
-
-        # figure out what user agent we are talking to
-        ua = request.META.get("HTTP_USER_AGENT")
-
-        if request.path.endswith(".rdf"):
-            return f(request, **kwargs)
-        elif ua and "MSIE" in ua:
-            return html_redirect
-        elif match == "application/rdf+xml":
-            response = f(request, **kwargs)
-            response["Vary"] = "Accept"
-            return response
-        elif match == "text/html":
-            return html_redirect
-        else:
-            return HttpResponseUnsupportedMediaType()
-
-    return f1
-
-
 def opensearch_clean(f):
     """
     Some opensearch clients send along optional parameters from the opensearch

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -28,7 +28,7 @@ from django.views.decorators.vary import vary_on_headers
 from sendfile import sendfile
 
 from chronam.core import index, models
-from chronam.core.decorator import add_cache_headers, rdf_view
+from chronam.core.decorator import add_cache_headers
 from chronam.core.index import get_page_text
 from chronam.core.rdf import issue_to_graph, page_to_graph, title_to_graph
 from chronam.core.utils.url import unpack_url_path
@@ -113,7 +113,6 @@ def title_marc(request, lccn):
 
 
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
-@rdf_view
 def title_rdf(request, lccn):
     title = get_object_or_404(models.Title, lccn=lccn)
     graph = title_to_graph(title)
@@ -211,7 +210,6 @@ def issue_pages(request, lccn, date, edition, page_number=1):
 
 
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
-@rdf_view
 def issue_pages_rdf(request, lccn, date, edition):
     title, issue, page = _get_tip(lccn, date, edition)
     graph = issue_to_graph(issue)
@@ -607,7 +605,6 @@ def page_ocr_txt(request, lccn, date, edition, sequence):
 
 
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
-@rdf_view
 def page_rdf(request, lccn, date, edition, sequence):
     page = get_page(lccn, date, edition, sequence)
     graph = page_to_graph(page)

--- a/core/views/directory.py
+++ b/core/views/directory.py
@@ -12,7 +12,7 @@ from django.utils.encoding import smart_str
 from rfc3339 import rfc3339
 
 from chronam.core import index, models
-from chronam.core.decorator import add_cache_headers, cors, opensearch_clean, rdf_view
+from chronam.core.decorator import add_cache_headers, cors, opensearch_clean
 from chronam.core.rdf import titles_to_graph
 from chronam.core.utils.url import unpack_url_path
 from chronam.core.utils.utils import _page_range_short, _rdf_base, is_valid_jsonp_callback
@@ -300,7 +300,6 @@ def search_titles_results(request):
 
 
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
-@rdf_view
 def newspapers_rdf(request):
     titles = models.Title.objects.filter(has_issues=True)
     titles = titles.prefetch_related(

--- a/core/views/directory.py
+++ b/core/views/directory.py
@@ -19,7 +19,7 @@ from chronam.core.utils.utils import _page_range_short, _rdf_base, is_valid_json
 
 
 @add_cache_headers(settings.METADATA_TTL_SECONDS)
-def newspapers(request, state=None, format='html'):
+def newspapers(request, state=None, format="html"):
     if state and state != "all_states":
         state = unpack_url_path(state)
         if state is None:
@@ -27,10 +27,10 @@ def newspapers(request, state=None, format='html'):
         else:
             state = state.title()
     else:
-        state = request.GET.get('state')
+        state = request.GET.get("state")
 
     language = language_display = None
-    language_code = request.GET.get('language')
+    language_code = request.GET.get("language")
     if language_code:
         language = models.Language.objects.filter(code__startswith=language_code).first()
         if not language:
@@ -38,16 +38,16 @@ def newspapers(request, state=None, format='html'):
         else:
             language_code = language.code
             language_display = language.name
-    ethnicity = request.GET.get('ethnicity')
+    ethnicity = request.GET.get("ethnicity")
 
     if not state and not language and not ethnicity:
-        page_title = 'All Digitized Newspapers'
+        page_title = "All Digitized Newspapers"
     else:
-        page_title = 'Results: Digitized Newspapers'
+        page_title = "Results: Digitized Newspapers"
 
     titles = models.Title.objects.filter(has_issues=True)
-    titles = titles.annotate(first=Min('issues__date_issued'))
-    titles = titles.annotate(last=Max('issues__date_issued'))
+    titles = titles.annotate(first=Min("issues__date_issued"))
+    titles = titles.annotate(last=Max("issues__date_issued"))
 
     if state:
         titles = titles.filter(places__state__iexact=state)
@@ -66,7 +66,7 @@ def newspapers(request, state=None, format='html'):
             pass
 
     _newspapers_by_state = {}
-    for title in titles.prefetch_related('places'):
+    for title in titles.prefetch_related("places"):
         if state:
             _newspapers_by_state.setdefault(state, set()).add(title)
         else:
@@ -74,43 +74,56 @@ def newspapers(request, state=None, format='html'):
                 if place.state:
                     _newspapers_by_state.setdefault(place.state, set()).add(title)
 
-    newspapers_by_state = [(s, sorted(t, key=lambda title: title.name_normal))
-                           for s, t in sorted(_newspapers_by_state.iteritems())]
+    newspapers_by_state = [
+        (s, sorted(t, key=lambda title: title.name_normal))
+        for s, t in sorted(_newspapers_by_state.iteritems())
+    ]
     crumbs = list(settings.BASE_CRUMBS)
 
     if format == "html":
-        return render_to_response("newspapers.html",
-                                  dictionary=locals(),
-                                  context_instance=RequestContext(request))
+        return render_to_response(
+            "newspapers.html", dictionary=locals(), context_instance=RequestContext(request)
+        )
     elif format == "txt":
         host = request.get_host()
-        return render_to_response("newspapers.txt",
-                                  dictionary=locals(),
-                                  context_instance=RequestContext(request),
-                                  content_type="text/plain")
+        return render_to_response(
+            "newspapers.txt",
+            dictionary=locals(),
+            context_instance=RequestContext(request),
+            content_type="text/plain",
+        )
     elif format == "csv":
-        csv_header_labels = ('Persistent Link', 'State', 'Title', 'LCCN', 'OCLC',
-                             'ISSN', 'No. of Issues', 'First Issue Date',
-                             'Last Issue Date', 'More Info')
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename="chronam_newspapers.csv"'
+        csv_header_labels = (
+            "Persistent Link",
+            "State",
+            "Title",
+            "LCCN",
+            "OCLC",
+            "ISSN",
+            "No. of Issues",
+            "First Issue Date",
+            "Last Issue Date",
+            "More Info",
+        )
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = 'attachment; filename="chronam_newspapers.csv"'
         writer = csv.writer(response)
         writer.writerow(csv_header_labels)
         for state, titles in newspapers_by_state:
             for title in titles:
                 writer.writerow(
                     (
-                        request.build_absolute_uri(reverse('chronam_issues', kwargs={'lccn': title.lccn})),
+                        request.build_absolute_uri(reverse("chronam_issues", kwargs={"lccn": title.lccn})),
                         state,
                         title,
-                        title.lccn or '',
-                        title.oclc or '',
-                        title.issn or '',
+                        title.lccn or "",
+                        title.oclc or "",
+                        title.issn or "",
                         title.issues.count(),
                         title.first,
                         title.last,
                         request.build_absolute_uri(
-                            reverse('chronam_title_essays', kwargs={'lccn': title.lccn})
+                            reverse("chronam_title_essays", kwargs={"lccn": title.lccn})
                         ),
                     )
                 )
@@ -129,7 +142,7 @@ def newspapers(request, state=None, format='html'):
                     }
                 )
 
-        return HttpResponse(json.dumps(results), content_type='application/json')
+        return HttpResponse(json.dumps(results), content_type="application/json")
     else:
         return HttpResponseServerError("unsupported format: %s" % format)
 
@@ -138,56 +151,79 @@ def newspapers(request, state=None, format='html'):
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
 @opensearch_clean
 def search_titles_results(request):
-    page_title = 'US Newspaper Directory Search Results'
+    page_title = "US Newspaper Directory Search Results"
     crumbs = list(settings.BASE_CRUMBS)
-    crumbs.extend([{'label': 'Search Newspaper Directory',
-                    'href': reverse('chronam_search_titles')},
-                   ])
+    crumbs.extend([{"label": "Search Newspaper Directory", "href": reverse("chronam_search_titles")}])
 
     def prep_title_for_return(t):
         title = {}
         title.update(t.solr_doc)
-        title['oclc'] = t.oclc
+        title["oclc"] = t.oclc
         return title
 
-    format = request.GET.get('format')
+    format = request.GET.get("format")
 
     # check if requested format is CSV before building pages for response. CSV
     # response does not make use of pagination, instead all matching titles from
     # SOLR are returned at once
-    if format == 'csv':
+    if format == "csv":
         query = request.GET.copy()
         q, fields, sort_field, sort_order = index.get_solr_request_params_from_query(query)
 
         # return all titles in csv format. * May hurt performance. Assumption is that this
         # request is not made often.
         # TODO: revisit if assumption is incorrect
-        solr_response = index.execute_solr_query(q, fields, sort_field,
-                                                 sort_order, index.title_count(), 0)
+        solr_response = index.execute_solr_query(q, fields, sort_field, sort_order, index.title_count(), 0)
         titles = index.get_titles_from_solr_documents(solr_response)
 
-        csv_header_labels = ('lccn', 'title', 'place_of_publication', 'start_year',
-                             'end_year', 'publisher', 'edition', 'frequency', 'subject',
-                             'state', 'city', 'country', 'language', 'oclc',
-                             'holding_type',)
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename="chronam_titles.csv"'
+        csv_header_labels = (
+            "lccn",
+            "title",
+            "place_of_publication",
+            "start_year",
+            "end_year",
+            "publisher",
+            "edition",
+            "frequency",
+            "subject",
+            "state",
+            "city",
+            "country",
+            "language",
+            "oclc",
+            "holding_type",
+        )
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = 'attachment; filename="chronam_titles.csv"'
         writer = csv.writer(response)
         writer.writerow(csv_header_labels)
         for title in titles:
-            writer.writerow(map(lambda val: smart_str(val or '--'),
-                                (title.lccn, title.name, title.place_of_publication,
-                                 title.start_year, title.end_year, title.publisher,
-                                 title.edition, title.frequency,
-                                 map(str, title.subjects.all()),
-                                 set(map(lambda p: p.state, title.places.all())),
-                                 map(lambda p: p.city, title.places.all()),
-                                 str(title.country), map(str, title.languages.all()),
-                                 title.oclc, title.holding_types)))
+            writer.writerow(
+                map(
+                    lambda val: smart_str(val or "--"),
+                    (
+                        title.lccn,
+                        title.name,
+                        title.place_of_publication,
+                        title.start_year,
+                        title.end_year,
+                        title.publisher,
+                        title.edition,
+                        title.frequency,
+                        map(str, title.subjects.all()),
+                        set(map(lambda p: p.state, title.places.all())),
+                        map(lambda p: p.city, title.places.all()),
+                        str(title.country),
+                        map(str, title.languages.all()),
+                        title.oclc,
+                        title.holding_types,
+                    ),
+                )
+            )
         return response
 
     try:
-        curr_page = int(request.GET.get('page', 1))
+        curr_page = int(request.GET.get("page", 1))
     except ValueError as e:
         curr_page = 1
 
@@ -201,18 +237,18 @@ def search_titles_results(request):
     page_range_short = list(_page_range_short(paginator, page))
 
     try:
-        rows = int(request.GET.get('rows', '20'))
+        rows = int(request.GET.get("rows", "20"))
     except ValueError as e:
         rows = 20
 
     query = request.GET.copy()
     query.rows = rows
     if page.has_next():
-        query['page'] = curr_page + 1
-        next_url = '?' + query.urlencode()
+        query["page"] = curr_page + 1
+        next_url = "?" + query.urlencode()
     if page.has_previous():
-        query['page'] = curr_page - 1
-        previous_url = '?' + query.urlencode()
+        query["page"] = curr_page - 1
+        previous_url = "?" + query.urlencode()
     start = page.start_index()
     end = page.end_index()
     host = request.get_host()
@@ -221,46 +257,46 @@ def search_titles_results(request):
         page_start = start + p
         page_list.append((page_start, page.object_list[p]))
 
-    if format == 'atom':
+    if format == "atom":
         feed_url = request.build_absolute_uri()
         updated = rfc3339(datetime.datetime.now())
         return render_to_response(
-            'search_titles_results.xml',
+            "search_titles_results.xml",
             dictionary=locals(),
             context_instance=RequestContext(request),
-            content_type='application/atom+xml',
+            content_type="application/atom+xml",
         )
 
-    elif format == 'json':
+    elif format == "json":
         results = {
-            'startIndex': start,
-            'endIndex': end,
-            'totalItems': paginator.count,
-            'itemsPerPage': rows,
-            'items': [prep_title_for_return(t) for t in page.object_list]
+            "startIndex": start,
+            "endIndex": end,
+            "totalItems": paginator.count,
+            "itemsPerPage": rows,
+            "items": [prep_title_for_return(t) for t in page.object_list],
         }
         # add url for the json view
-        for i in results['items']:
-            i['url'] = request.build_absolute_uri(i['id'].rstrip("/") + ".json")
+        for i in results["items"]:
+            i["url"] = request.build_absolute_uri(i["id"].rstrip("/") + ".json")
         json_text = json.dumps(results)
         # jsonp?
-        callback = request.GET.get('callback')
+        callback = request.GET.get("callback")
         if callback and is_valid_jsonp_callback(callback):
-            json_text = "%s(%s);" % ('callback', json_text)
-        return HttpResponse(json_text, content_type='application/json')
+            json_text = "%s(%s);" % ("callback", json_text)
+        return HttpResponse(json_text, content_type="application/json")
 
-    sort = request.GET.get('sort', 'relevance')
+    sort = request.GET.get("sort", "relevance")
 
     q = request.GET.copy()
-    if 'page' in q:
-        del q['page']
-    if 'sort' in q:
-        del q['sort']
+    if "page" in q:
+        del q["page"]
+    if "sort" in q:
+        del q["sort"]
     q = q.urlencode()
     collapse_search_tab = True
-    return render_to_response('search_titles_results.html',
-                              dictionary=locals(),
-                              context_instance=RequestContext(request))
+    return render_to_response(
+        "search_titles_results.html", dictionary=locals(), context_instance=RequestContext(request)
+    )
 
 
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
@@ -268,18 +304,18 @@ def search_titles_results(request):
 def newspapers_rdf(request):
     titles = models.Title.objects.filter(has_issues=True)
     titles = titles.prefetch_related(
-        'subjects',
-        'languages',
-        'essays',
-        'places',
-        'urls',
-        'succeeding_title_links',
-        'preceeding_title_links',
-        'related_title_links',
+        "subjects",
+        "languages",
+        "essays",
+        "places",
+        "urls",
+        "succeeding_title_links",
+        "preceeding_title_links",
+        "related_title_links",
     )
-    titles = titles.select_related('marc')
+    titles = titles.select_related("marc")
 
     graph = titles_to_graph(titles)
-    return HttpResponse(graph.serialize(base=_rdf_base(request),
-                                        include_base=True),
-                        content_type='application/rdf+xml')
+    return HttpResponse(
+        graph.serialize(base=_rdf_base(request), include_base=True), content_type="application/rdf+xml"
+    )

--- a/core/views/image.py
+++ b/core/views/image.py
@@ -22,7 +22,7 @@ if settings.USE_TIFF:
 else:
     import NativeImaging
 
-    for backend in ('aware', 'graphicsmagick'):
+    for backend in ("aware", "graphicsmagick"):
         try:
             Image = NativeImaging.get_image_class(backend)
             LOGGER.info("Using NativeImage backend '%s'", backend)
@@ -91,7 +91,7 @@ def page_image(request, lccn, date, edition, sequence, width, height):
 
 def page_image_tile(request, lccn, date, edition, sequence, width, height, x1, y1, x2, y2):
     page = get_page(lccn, date, edition, sequence)
-    if 'download' in request.GET and request.GET['download']:
+    if "download" in request.GET and request.GET["download"]:
         response = HttpResponse(content_type="binary/octet-stream")
     else:
         response = HttpResponse(content_type="image/jpeg")
@@ -113,7 +113,7 @@ def page_image_tile(request, lccn, date, edition, sequence, width, height, x1, y
 
 
 def image_tile(request, path, width, height, x1, y1, x2, y2):
-    if 'download' in request.GET and request.GET['download']:
+    if "download" in request.GET and request.GET["download"]:
         response = HttpResponse(content_type="binary/octet-stream")
     else:
         response = HttpResponse(content_type="image/jpeg")
@@ -138,9 +138,9 @@ def coordinates(request, lccn, date, edition, sequence, words=None):
     file_path = models.coordinates_path(url_parts)
 
     try:
-        with gzip.open(file_path, 'rb') as i:
-            response = HttpResponse(i.read(), content_type='application/json')
+        with gzip.open(file_path, "rb") as i:
+            response = HttpResponse(i.read(), content_type="application/json")
             return add_cache_tag(response, "lccn=%s" % lccn)
     except IOError:
-        LOGGER.warning('Word coordinates file %s does not exist', file_path)
+        LOGGER.warning("Word coordinates file %s does not exist", file_path)
         raise Http404

--- a/core/views/reports.py
+++ b/core/views/reports.py
@@ -15,7 +15,7 @@ from rfc3339 import rfc3339
 from tabular_export.core import export_to_csv_response, flatten_queryset
 
 from chronam.core import index, models
-from chronam.core.decorator import add_cache_headers, cors, rdf_view
+from chronam.core.decorator import add_cache_headers, cors
 from chronam.core.rdf import awardee_to_graph, batch_to_graph
 from chronam.core.utils.url import unpack_url_path
 from chronam.core.utils.utils import _get_tip, _page_range_short, _rdf_base
@@ -142,7 +142,6 @@ def batch(request, batch_name):
     )
 
 
-@rdf_view
 @never_cache
 def batch_rdf(request, batch_name):
     batch = get_object_or_404(models.Batch, name=batch_name)
@@ -428,7 +427,6 @@ def awardee_json(request, institution_code):
 
 
 @add_cache_headers(settings.METADATA_TTL_SECONDS)
-@rdf_view
 def awardee_rdf(request, institution_code):
     awardee = get_object_or_404(models.Awardee, org_code=institution_code)
     graph = awardee_to_graph(awardee)

--- a/core/views/static.py
+++ b/core/views/static.py
@@ -18,66 +18,51 @@ from chronam.core.models import Language
 @never_cache
 def healthz(request):
     status = {
-        'current_time': time.time(),
-        'load_average': os.getloadavg(),
-        'process_creation_time': Process().create_time(),
+        "current_time": time.time(),
+        "load_average": os.getloadavg(),
+        "process_creation_time": Process().create_time(),
     }
 
     # We don't want to query a large table but we do want to hit the database
     # at last once:
-    status['database_has_data'] = Language.objects.count() > 0
+    status["database_has_data"] = Language.objects.count() > 0
 
     # We'll intentionally touch the storage paths to turn failed network mounts
     # into failed health-checks. This would be less generic if we did an
     # os.path.ismount() tests on the ones which are independent mounts so we're
     # not doing that.
-    status['storage'] = {
+    status["storage"] = {
         k: os.path.isdir(getattr(settings, k))
-        for k in ('BATCH_STORAGE', 'BIB_STORAGE', 'COORD_STORAGE', 'OCR_DUMP_STORAGE', 'TEMP_STORAGE')
+        for k in ("BATCH_STORAGE", "BIB_STORAGE", "COORD_STORAGE", "OCR_DUMP_STORAGE", "TEMP_STORAGE")
     }
 
-    return HttpResponse(content=json.dumps(status), content_type='application/json')
+    return HttpResponse(content=json.dumps(status), content_type="application/json")
 
 
 @add_cache_headers(settings.LONG_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)
 def about(request):
     page_title = "About Chronicling America"
     crumbs = list(settings.BASE_CRUMBS)
-    crumbs.extend([
-        {'label': 'About',
-         'href': urlresolvers.reverse('chronam_about'),
-         'active': True},
-    ])
-    return render_to_response('about.html', dictionary=locals(),
-                              context_instance=RequestContext(request))
+    crumbs.extend([{"label": "About", "href": urlresolvers.reverse("chronam_about"), "active": True}])
+    return render_to_response("about.html", dictionary=locals(), context_instance=RequestContext(request))
 
 
 @add_cache_headers(settings.LONG_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)
 def about_api(request):
     page_title = "About the Site and API"
     crumbs = list(settings.BASE_CRUMBS)
-    crumbs.extend([
-        {'label': 'About API',
-         'href': urlresolvers.reverse('chronam_about_api'),
-         'active': True},
-    ])
-    return render_to_response('about_api.html', dictionary=locals(),
-                              context_instance=RequestContext(request))
+    crumbs.extend([{"label": "About API", "href": urlresolvers.reverse("chronam_about_api"), "active": True}])
+    return render_to_response("about_api.html", dictionary=locals(), context_instance=RequestContext(request))
 
 
 @add_cache_headers(settings.LONG_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)
 def help(request):
     page_title = "Help"
     crumbs = list(settings.BASE_CRUMBS)
-    crumbs.extend([
-        {'label': 'Help',
-         'href': urlresolvers.reverse('chronam_help'),
-         'active': True},
-    ])
-    return render_to_response('help.html', dictionary=locals(),
-                              context_instance=RequestContext(request))
+    crumbs.extend([{"label": "Help", "href": urlresolvers.reverse("chronam_help"), "active": True}])
+    return render_to_response("help.html", dictionary=locals(), context_instance=RequestContext(request))
 
 
 @add_cache_headers(settings.LONG_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)
 def favicon(request):
-    return HttpResponseRedirect(static('img-std/fav.ico'))
+    return HttpResponseRedirect(static("img-std/fav.ico"))

--- a/urls.py
+++ b/urls.py
@@ -45,20 +45,20 @@ urlpatterns = [
         name="chronam_home_date",
     ),
     url(
-        r"^frontpages/(?P<date>\d{4}-\d{1,2}-\d{1,2}).json$",
+        r"^frontpages/(?P<date>\d{4}-\d{1,2}-\d{1,2})\.json$",
         add_cache_headers(settings.DEFAULT_TTL_SECONDS)(views.home.frontpages),
         name="chronam_frontpages_date_json",
     ),
     url(r"^tabs$", views.home.tabs, name="chronam_tabs"),
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/thumbnail.jpg$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/thumbnail\.jpg$",
         add_cache_headers(settings.PAGE_IMAGE_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)(
             views.image.thumbnail
         ),
         name="chronam_page_thumbnail",
     ),
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/medium.jpg$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/medium\.jpg$",
         add_cache_headers(settings.PAGE_IMAGE_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)(
             views.image.medium
         ),
@@ -66,7 +66,7 @@ urlpatterns = [
     ),
     # example: /lccn/sn85066387/1907-03-17/ed-1/seq-4/image_813x1024_from_0,0_to_6504,8192.jpg
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/image_(?P<width>\d+)x(?P<height>\d+)_from_(?P<x1>\d+),(?P<y1>\d+)_to_(?P<x2>\d+),(?P<y2>\d+).jpg$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/image_(?P<width>\d+)x(?P<height>\d+)_from_(?P<x1>\d+),(?P<y1>\d+)_to_(?P<x2>\d+),(?P<y2>\d+)\.jpg$",
         add_cache_headers(settings.PAGE_IMAGE_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)(
             views.image.page_image_tile
         ),
@@ -74,7 +74,7 @@ urlpatterns = [
     ),
     # example: /tiles/batch_dlc_jamaica_ver01/data/sn83030214/00175042143/1903051701/0299.jp2/image_813x1024_from_0,0_to_6504,8192.jpg
     url(
-        r"^images/tiles/(?P<path>.+)/image_(?P<width>\d+)x(?P<height>\d+)_from_(?P<x1>\d+),(?P<y1>\d+)_to_(?P<x2>\d+),(?P<y2>\d+).jpg$",
+        r"^images/tiles/(?P<path>.+)/image_(?P<width>\d+)x(?P<height>\d+)_from_(?P<x1>\d+),(?P<y1>\d+)_to_(?P<x2>\d+),(?P<y2>\d+)\.jpg$",
         add_cache_headers(settings.PAGE_IMAGE_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)(
             views.image.image_tile
         ),
@@ -82,7 +82,7 @@ urlpatterns = [
     ),
     # example: /lccn/sn85066387/1907-03-17/ed-1/seq-4/image_813x1024.jpg
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/image_(?P<width>\d+)x(?P<height>\d+).jpg$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/image_(?P<width>\d+)x(?P<height>\d+)\.jpg$",
         add_cache_headers(settings.PAGE_IMAGE_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)(
             views.image.page_image
         ),
@@ -138,7 +138,7 @@ urlpatterns += [
     # example: /lccn/sn85066387/feed/10
     url(r"^lccn/(?P<lccn>\w+)/feed/(?P<page_number>\w+)$", views.title_atom, name="chronam_title_atom_page"),
     # example: /lccn/sn85066387/marc.xml
-    url(r"^lccn/(?P<lccn>\w+)/marc.xml$", views.title_marcxml, name="chronam_title_marcxml"),
+    url(r"^lccn/(?P<lccn>\w+)/marc\.xml$", views.title_marcxml, name="chronam_title_marcxml"),
     # example: /lccn/sn85066387/holdings
     url(r"^lccn/(?P<lccn>\w+)/holdings/$", views.title_holdings, name="chronam_title_holdings"),
     # example: /essays/
@@ -169,25 +169,25 @@ urlpatterns += [
     ),
     # example: /lccn/sn85066387/1907-03-17/ed-1/seq-4.pdf
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+).pdf$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)\.pdf$",
         views.page_pdf,
         name="chronam_page_pdf",
     ),
     # example: /lccn/sn85066387/1907-03-17/ed-1/seq-4.jp2
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+).jp2$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)\.jp2$",
         views.page_jp2,
         name="chronam_page_jp2",
     ),
     # example: /lccn/sn85066387/1907-03-17/ed-1/seq-4/ocr.xml
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/ocr.xml$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/ocr\.xml$",
         views.page_ocr_xml,
         name="chronam_page_ocr_xml",
     ),
     # example: /lccn/sn85066387/1907-03-17/ed-1/seq-4/ocr.txt
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/ocr.txt$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)/ocr\.txt$",
         views.page_ocr_txt,
         name="chronam_page_ocr_txt",
     ),
@@ -245,7 +245,7 @@ urlpatterns += [
     url(r"^events/feed/$", views.events_atom, name="chronam_events_atom"),
     url(r"^events/feed/(?P<page_number>\d+)/$", views.events_atom, name="chronam_events_atom_page"),
     url(r"^awardees/$", views.awardees, name="chronam_awardees"),
-    url(r"^awardees.json$", views.awardees_json, name="chronam_awardees_json"),
+    url(r"^awardees\.json$", views.awardees_json, name="chronam_awardees_json"),
     # example: /titles
     url(r"^titles/$", views.titles, name="chronam_titles"),
     # example: /titles;page=5
@@ -358,7 +358,7 @@ urlpatterns += [
     ),
     # awardee
     url(r"^awardees/(?P<institution_code>\w+)/$", views.awardee, name="chronam_awardee"),
-    url(r"^awardees/(?P<institution_code>\w+).json$", views.awardee_json, name="chronam_awardee_json"),
+    url(r"^awardees/(?P<institution_code>\w+)\.json$", views.awardee_json, name="chronam_awardee_json"),
     url(r"^status", views.status, name="chronam_stats"),
 ]
 
@@ -366,20 +366,20 @@ urlpatterns += [
 
 urlpatterns += [
     # newspapers
-    url(r"^newspapers.rdf$", views.newspapers_rdf, name="chronam_newspapers_dot_rdf"),
     url(r"^newspapers$", views.newspapers_rdf, name="chronam_newspapers_rdf"),
+    url(r"^newspapers\.rdf$", views.newspapers_rdf, name="chronam_newspapers_dot_rdf"),
     # title
-    url(r"^lccn/(?P<lccn>\w+).rdf$", views.title_rdf, name="chronam_title_dot_rdf"),
     url(r"^lccn/(?P<lccn>\w+)$", views.title_rdf, name="chronam_title_rdf"),
-    url(r"^lccn/(?P<lccn>\w+).json", views.title_json, name="chronam_title_dot_json"),
+    url(r"^lccn/(?P<lccn>\w+)\.rdf$", views.title_rdf, name="chronam_title_dot_rdf"),
+    url(r"^lccn/(?P<lccn>\w+)\.json", views.title_json, name="chronam_title_dot_json"),
     # issue
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+).rdf$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)\.rdf$",
         views.issue_pages_rdf,
         name="chronam_issue_pages_dot_rdf",
     ),
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+).json$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)\.json$",
         views.issue_pages_json,
         name="chronam_issue_pages_dot_json",
     ),
@@ -390,12 +390,12 @@ urlpatterns += [
     ),
     # page
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+).rdf$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)\.rdf$",
         views.page_rdf,
         name="chronam_page_dot_rdf",
     ),
     url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+).json$",
+        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)\.json$",
         views.page_json,
         name="chronam_page_dot_json",
     ),
@@ -405,8 +405,8 @@ urlpatterns += [
         name="chronam_page_rdf",
     ),
     # awardee
-    url(r"^awardees/(?P<institution_code>\w+).rdf$", views.awardee_rdf, name="chronam_awardee_dot_rdf"),
     url(r"^awardees/(?P<institution_code>\w+)$", views.awardee_rdf, name="chronam_awardee_rdf"),
+    url(r"^awardees/(?P<institution_code>\w+)\.rdf$", views.awardee_rdf, name="chronam_awardee_dot_rdf"),
     # ndnp vocabulary
     url(r"^terms/.*$", views.terms, name="chronam_terms"),
     # flickr report
@@ -421,9 +421,9 @@ urlpatterns += [
     url(r"^batches/feed/(?P<page_number>\d+)/$", views.batches_atom, name="chronam_batches_atom_page"),
     url(r"^batches\.json$", views.batches_json, name="chronam_batches_json"),
     url(r"^batches\.csv$", views.batches_csv, name="chronam_batches_csv"),
-    url(r"^batches/(?P<page_number>\d+).json$", views.batches_json, name="chronam_batches_json_page"),
+    url(r"^batches/(?P<page_number>\d+)\.json$", views.batches_json, name="chronam_batches_json_page"),
     url(r"^batches/(?P<batch_name>.+)/$", views.batch, name="chronam_batch"),
-    url(r"^batches/(?P<batch_name>.+).rdf$", views.batch_rdf, name="chronam_batch_dot_rdf"),
+    url(r"^batches/(?P<batch_name>.+)\.rdf$", views.batch_rdf, name="chronam_batch_dot_rdf"),
     url(r"^batches/(?P<batch_name>.+)\.json$", views.batch_json, name="chronam_batch_dot_json"),
     url(r"^batches/(?P<batch_name>.+)$", views.batch_rdf, name="chronam_batch_rdf"),
     # reels

--- a/urls.py
+++ b/urls.py
@@ -366,10 +366,8 @@ urlpatterns += [
 
 urlpatterns += [
     # newspapers
-    url(r"^newspapers$", views.newspapers_rdf, name="chronam_newspapers_rdf"),
     url(r"^newspapers\.rdf$", views.newspapers_rdf, name="chronam_newspapers_dot_rdf"),
     # title
-    url(r"^lccn/(?P<lccn>\w+)$", views.title_rdf, name="chronam_title_rdf"),
     url(r"^lccn/(?P<lccn>\w+)\.rdf$", views.title_rdf, name="chronam_title_dot_rdf"),
     url(r"^lccn/(?P<lccn>\w+)\.json", views.title_json, name="chronam_title_dot_json"),
     # issue
@@ -383,11 +381,6 @@ urlpatterns += [
         views.issue_pages_json,
         name="chronam_issue_pages_dot_json",
     ),
-    url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)$",
-        views.issue_pages_rdf,
-        name="chronam_issue_pages_rdf",
-    ),
     # page
     url(
         r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)\.rdf$",
@@ -399,13 +392,7 @@ urlpatterns += [
         views.page_json,
         name="chronam_page_dot_json",
     ),
-    url(
-        r"^lccn/(?P<lccn>\w+)/(?P<date>\d{4}-\d{2}-\d{2})/ed-(?P<edition>\d+)/seq-(?P<sequence>\d+)$",
-        views.page_rdf,
-        name="chronam_page_rdf",
-    ),
     # awardee
-    url(r"^awardees/(?P<institution_code>\w+)$", views.awardee_rdf, name="chronam_awardee_rdf"),
     url(r"^awardees/(?P<institution_code>\w+)\.rdf$", views.awardee_rdf, name="chronam_awardee_dot_rdf"),
     # ndnp vocabulary
     url(r"^terms/.*$", views.terms, name="chronam_terms"),
@@ -425,7 +412,6 @@ urlpatterns += [
     url(r"^batches/(?P<batch_name>.+)/$", views.batch, name="chronam_batch"),
     url(r"^batches/(?P<batch_name>.+)\.rdf$", views.batch_rdf, name="chronam_batch_dot_rdf"),
     url(r"^batches/(?P<batch_name>.+)\.json$", views.batch_json, name="chronam_batch_dot_json"),
-    url(r"^batches/(?P<batch_name>.+)$", views.batch_rdf, name="chronam_batch_rdf"),
     # reels
     url(r"^reels/$", views.reels, name="chronam_reels"),
     url(r"^reels/;page=(?P<page_number>\d+)$", views.reels, name="chronam_reels_page"),


### PR DESCRIPTION
This was lightly used since the pages link to the .rdf URLs and since it didn’t set the Vary header consistently the results were confusing based on whether a particular URL had been cached by a different class of client before. Since all of the links and documentation use the non-negotiated .rdf links we can simplify the logic by removing the negotiated views and letting Django’s normal APPEND_SLASH behavior handle any legacy links.