### PR TITLE
Set a more informative filename for clipping downloads

### DIFF
--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -619,7 +619,7 @@ def page_rdf(request, lccn, date, edition, sequence):
 
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS, settings.SHARED_CACHE_MAXAGE_SECONDS)
 def page_print(request, lccn, date, edition, sequence, width, height, x1, y1, x2, y2):
-    x1, y1, x2, y2 = map(int, (x1, y1, x2, y2))
+    width, height, x1, y1, x2, y2 = map(int, (width, height, x1, y1, x2, y2))
     page = get_page(lccn, date, edition, sequence)
     title = get_object_or_404(models.Title, lccn=lccn)
     issue = page.issue
@@ -640,6 +640,19 @@ def page_print(request, lccn, date, edition, sequence, width, height, x1, y1, x2
         "y2": y2,
     }
     url = urlresolvers.reverse("chronam_page_print", kwargs=path_parts)
+
+    download_filename = "%s %s %s %s image %dx%d from %dx%d to %dx%d.jpg" % (
+        lccn,
+        date,
+        edition,
+        sequence,
+        width,
+        height,
+        x1,
+        y1,
+        x2,
+        y2,
+    )
 
     if page.iiif_client:
         download_url = page.iiif_client.region(x=x1, y=y1, width=x2 - x1, height=y2 - y1)

--- a/loc/templates/page_print.html
+++ b/loc/templates/page_print.html
@@ -18,7 +18,7 @@
                     <strong>Print this image</strong>
                 </a>
                 |
-                <a class="clip_download" download href="{{ download_url }}">
+                <a class="clip_download" download="{{ download_filename }}" href="{{ download_url }}?response-content-disposition={% filter urlencode %}attachment; filename="{{ download_filename }}"{% endfilter %}">
                     <strong>
                         Download this image
                     </strong>


### PR DESCRIPTION
This uses the <a download> attribute and the Content-Disposition header to set a filename which includes the LCCN, date, edition, sequence, etc.

Unfortunately, completing this appears to depend on resolving https://github.com/cantaloupe-project/cantaloupe/issues/301 first.