### PR TITLE
Fix content negotiation for RDF views

### DIFF
--- a/conf/default.vcl
+++ b/conf/default.vcl
@@ -106,12 +106,13 @@ sub vcl_hit {
     return (fetch);
 }
 
-#Preserve any Vary headers from the backend but ensure that Vary always includes Accept-Encoding since we enable gzip transfer encoding
+# Preserve any Vary headers from the backend but ensure that Vary always
+# includes Accept-Encoding since we enable gzip transfer encoding
 sub vcl_deliver {
     if (!resp.http.Vary) {
         set resp.http.Vary = "Accept-Encoding";
     } else if (resp.http.Vary !~ "(?i)Accept-Encoding") {
-        set resp.http.Vary = resp.http.Vary + ",Accept-Encoding";
+        set resp.http.Vary = "Accept-Encoding," + resp.http.Vary;
     }
 }
 

--- a/core/decorator.py
+++ b/core/decorator.py
@@ -4,6 +4,7 @@ from functools import wraps
 from django.core import urlresolvers
 from django.http import HttpResponse
 from django.utils import cache, encoding
+from django.views.decorators.vary import vary_on_headers
 from mimeparse import best_match
 
 
@@ -40,36 +41,39 @@ def add_cache_headers(ttl, shared_cache_maxage=None):
     return decorator
 
 
-def rdf_view(f):
-    @wraps(f)
-    def f1(request, **kwargs):
-        # construct a http redirect response to html view
-        html_view = f.func_name.replace("_rdf", "")
-        html_url = urlresolvers.reverse("chronam_%s" % html_view, kwargs=kwargs)
-        html_redirect = HttpResponseSeeOther(html_url)
-
-        # determine the clients preferred representation
-        available = ["text/html", "application/rdf+xml"]
-        accept = request.META.get("HTTP_ACCEPT", "application/rdf+xml")
-        match = best_match(available, accept)
-
-        # figure out what user agent we are talking to
-        ua = request.META.get("HTTP_USER_AGENT")
-
+def rdf_view(rdf_view_func):
+    @wraps(rdf_view_func)
+    def inner(request, **kwargs):
+        # The RDF views which have an extension are not negotiated so they can
+        # be processed and cached simply:
         if request.path.endswith(".rdf"):
-            return f(request, **kwargs)
-        elif ua and "MSIE" in ua:
-            return html_redirect
-        elif match == "application/rdf+xml":
-            response = f(request, **kwargs)
-            response["Vary"] = "Accept"
-            return response
-        elif match == "text/html":
-            return html_redirect
+            return rdf_view_func(request, **kwargs)
         else:
-            return HttpResponseUnsupportedMediaType()
+            return negotiate_rdf_response(rdf_view_func, request, **kwargs)
 
-    return f1
+    return inner
+
+
+@vary_on_headers("Accept", "User-Agent")
+def negotiate_rdf_response(rdf_view_func, request, **kwargs):
+    # construct a http redirect response to html view
+    html_view = rdf_view_func.func_name.replace("_rdf", "")
+    html_url = urlresolvers.reverse("chronam_%s" % html_view, kwargs=kwargs)
+    html_redirect = HttpResponseSeeOther(html_url)
+
+    # determine the clients preferred representation
+    available = ["text/html", "application/rdf+xml"]
+    accept = request.META.get("HTTP_ACCEPT", "application/rdf+xml")
+    match = best_match(available, accept)
+
+    if "MSIE" in request.META.get("HTTP_USER_AGENT", ""):
+        return html_redirect
+    elif match == "application/rdf+xml":
+        return rdf_view_func(request, **kwargs)
+    elif match == "text/html":
+        return html_redirect
+    else:
+        return HttpResponseUnsupportedMediaType()
 
 
 def opensearch_clean(f):


### PR DESCRIPTION
This code path was fortunately only infrequently used — most of the links generated outside of the RDF payloads use the non-negotiated HTML or RDF URLs — but the source of infrequent bug reports because the response type varies depending on the User-Agent and Accept headers but only one of the five response paths set the Vary header and then only with one of the two headers used in the decision process.