### PR TITLE
Avoid stretching “100 years ago” thumbnails

### DIFF
--- a/loc/static/base.css
+++ b/loc/static/base.css
@@ -1772,6 +1772,9 @@ img.highlite {
 }
 img.thumbnail {
     border: 2px solid #ccc;
+    background-color: black;
+    object-fit: scale-down;
+    object-position: top;
 }
 .search_results_body ul.results_list {
     list-style: none;

--- a/loc/static/base.css
+++ b/loc/static/base.css
@@ -322,10 +322,6 @@ form select.sel {
     border: 1px solid #999;
     margin: 2px 0;
 }
-form input.radio,
-form input.check {
-    /* nothing here yet */
-}
 form .error span,
 form .error label,
 form .error .label_alt,
@@ -403,9 +399,6 @@ form textarea.std {
 .req {
     background-color: #eee;
     padding: 5px 7px;
-}
-.required {
-    /*color:#900;*/
 }
 .box-error {
     padding: 9px 9px 0 9px;
@@ -1999,14 +1992,8 @@ table.marc-record th,
 table.marc-record td {
     padding: 2px 6px 2px 0;
 }
-table.marc-record tr.marc-leader {
-}
-table.marc-record td.marc-field-indicators {
-}
 table.marc-record span.marc-subfield-code {
     color: #690;
-}
-table.marc-record span.marc-subfield-value {
 }
 
 /********************* about *********************/


### PR DESCRIPTION
This avoids the stretching introduced in https://github.com/LibraryOfCongress/chronam/commit/17d63a53347de3e631852fd2172a1caa669dfcb4#diff-d6dd3247bbe5766e339bbdbeaddb0e3aR37 for images which don't have aspect ratios which scale evenly to 200x286px:

## Before

![Screenshot_2019-08-29 Chronicling America « Library of Congress(1)](https://user-images.githubusercontent.com/46565/63948201-41aeb180-ca46-11e9-9287-3534d2a7ecb5.png)

## After

![Screenshot_2019-08-29 Chronicling America « Library of Congress(2)](https://user-images.githubusercontent.com/46565/63948218-45dacf00-ca46-11e9-95f6-35e44680d5fb.png)
