### PR TITLE
pin piffle to 0.3.0

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -20,6 +20,6 @@ django-sendfile==0.3.11
 psutil>=5.4.0
 beautifulsoup4==4.6.0
 requests==2.9.1
-piffle>=0.3.0
+piffle==0.3.0
 more-itertools==5.0.0
 django-tabular-export==1.1.0


### PR DESCRIPTION
0.4.0 breaks things with python 2.7.5