### PR TITLE
adds default values for text fields

### DIFF
--- a/core/migrations/0008_auto_20211130_1437.py
+++ b/core/migrations/0008_auto_20211130_1437.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0007_index_issue_titles_with_dates'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='issuenote',
+            name='text',
+            field=models.TextField(default=b'', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='note',
+            name='text',
+            field=models.TextField(default=b'', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='pagenote',
+            name='text',
+            field=models.TextField(default=b'', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='physicaldescription',
+            name='text',
+            field=models.TextField(default=b'', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='publicationdate',
+            name='text',
+            field=models.CharField(default=b'', max_length=500, blank=True),
+        ),
+    ]
+

--- a/core/models.py
+++ b/core/models.py
@@ -873,7 +873,7 @@ class OCR(models.Model):
 
 
 class PublicationDate(models.Model):
-    text = models.CharField(max_length=500)
+    text = models.CharField(max_length=500, blank=True, default="")
     titles = models.ForeignKey("Title", related_name="publication_dates")
 
     class Meta:
@@ -914,7 +914,7 @@ class Subject(models.Model):
 
 
 class Note(models.Model):
-    text = models.TextField()
+    text = models.TextField(blank=True, default="")
     type = models.CharField(max_length=3)
     title = models.ForeignKey("Title", related_name="notes")
 
@@ -927,7 +927,7 @@ class Note(models.Model):
 
 class PageNote(models.Model):
     label = models.TextField()
-    text = models.TextField()
+    text = models.TextField(blank=True, default="")
     type = models.CharField(max_length=50)
     page = models.ForeignKey("Page", related_name="notes")
 
@@ -940,7 +940,7 @@ class PageNote(models.Model):
 
 class IssueNote(models.Model):
     label = models.TextField()
-    text = models.TextField()
+    text = models.TextField(blank=True, default="")
     type = models.CharField(max_length=50)
     issue = models.ForeignKey("Issue", related_name="notes")
 
@@ -1142,7 +1142,7 @@ class Institution(models.Model):
 
 
 class PhysicalDescription(models.Model):
-    text = models.TextField()
+    text = models.TextField(blank=True, default="")
     type = models.CharField(max_length=3)
     title = models.ForeignKey("Title", related_name="dates_of_publication")
 


### PR DESCRIPTION
Adds default values for text fields to allow batch imports to work with mysql 8.

Without default values, loading batches with a MySQL 8 db throws the following error:
`unable to load batch: (1364, "Field 'text' doesn't have a default value")`

This PR adds default values of a blank string and allows the fields modified to be blank.
It also includes to Django generated migration file for this change.
