### PR TITLE
Update awardee values for 2021 awards

### DIFF
--- a/core/fixtures/initial_data.json
+++ b/core/fixtures/initial_data.json
@@ -403,8 +403,16 @@
         "pk": "rp",
         "model": "core.awardee",
         "fields": {
-            "name": "Providence Public Library, Providence, RI",
+            "name": "Rhode Island Digital Newspaper Project",
             "created": "2020-02-18 06:44:45"
+        }
+    },
+     {
+        "pk": "mb",
+        "model": "core.awardee",
+        "fields": {
+            "name": "Boston Public Library",
+            "created": "2022-01-31 06:44:45"
         }
     },
     {

--- a/core/fixtures/initial_data.json
+++ b/core/fixtures/initial_data.json
@@ -391,7 +391,7 @@
             "created": "2020-02-18 06:44:45"
         }
     },
-     {
+    {
         "pk": "wyu",
         "model": "core.awardee",
         "fields": {
@@ -399,7 +399,7 @@
             "created": "2020-02-18 06:44:45"
         }
     },
-     {
+    {
         "pk": "rp",
         "model": "core.awardee",
         "fields": {
@@ -407,7 +407,7 @@
             "created": "2020-02-18 06:44:45"
         }
     },
-     {
+    {
         "pk": "mb",
         "model": "core.awardee",
         "fields": {


### PR DESCRIPTION
- Update the name associated with awardee "rp" to be "Rhode Island Digital Newspaper Project";
- Add new awardee code="mb" name="Boston Public Library";