### PR TITLE
Set X-Robots-Tag: nofollow, index on search results pages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,10 @@ repos:
       rev: v5.10.1
       hooks:
           - id: isort
+    - repo: https://github.com/psf/black
+      rev: 22.1.0
+      hooks:
+          - id: black
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.1.0
       hooks:
@@ -35,7 +39,7 @@ repos:
           - id: prettier
             files: \.(css|less|scss|ts|tsx|graphql|gql|json|js|jsx|md)$
     - repo: https://github.com/pre-commit/mirrors-eslint
-      rev: v8.7.0
+      rev: v8.8.0
       hooks:
           - id: eslint
             additional_dependencies:

--- a/core/decorator.py
+++ b/core/decorator.py
@@ -117,3 +117,20 @@ def cors(f, *args, **kwargs):
         return response
 
     return new_f
+
+
+def robots_tag(f, tags=("noindex", "nofollow"), *args, **kwargs):
+    """
+    Set the X-Robots-Tag header on a response to tell robots how to process the
+    results.
+
+    https://developers.google.com/search/docs/advanced/robots/robots_meta_tag
+    """
+
+    @wraps(f)
+    def new_f(*args, **kwargs):
+        response = f(*args, **kwargs)
+        response["X-Robots-Tag"] = ", ".join(tags)
+        return response
+
+    return new_f

--- a/core/views/search.py
+++ b/core/views/search.py
@@ -19,7 +19,7 @@ from django.template import RequestContext
 from rfc3339 import rfc3339
 
 from chronam.core import forms, index, models
-from chronam.core.decorator import add_cache_headers, cors, opensearch_clean
+from chronam.core.decorator import add_cache_headers, cors, opensearch_clean, robots_tag
 from chronam.core.utils.utils import _page_range_short, is_valid_jsonp_callback
 
 
@@ -41,6 +41,7 @@ def search_pages_paginator(request):
     return paginator
 
 
+@robots_tag
 @cors
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
 @opensearch_clean
@@ -136,6 +137,7 @@ def search_pages_results(request, view_type="gallery"):
     return render_to_response(template, dictionary=locals(), context_instance=RequestContext(request))
 
 
+@robots_tag
 @add_cache_headers(settings.METADATA_TTL_SECONDS)
 def search_titles(request):
     browse_val = [chr(n) for n in range(65, 91)]
@@ -150,6 +152,7 @@ def search_titles(request):
     return render_to_response(template, dictionary=locals(), context_instance=RequestContext(request))
 
 
+@robots_tag
 @add_cache_headers(settings.METADATA_TTL_SECONDS)
 def search_titles_opensearch(request):
     host = request.get_host()
@@ -161,6 +164,7 @@ def search_titles_opensearch(request):
     )
 
 
+@robots_tag
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
 def search_pages_opensearch(request):
     host = request.get_host()
@@ -172,6 +176,7 @@ def search_pages_opensearch(request):
     )
 
 
+@robots_tag
 @cors
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
 def suggest_titles(request):
@@ -204,6 +209,7 @@ def suggest_titles(request):
     return HttpResponse(json_text, content_type="application/x-suggestions+json")
 
 
+@robots_tag
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
 def search_pages_navigation(request):
     """Search results navigation data
@@ -236,6 +242,7 @@ def search_pages_navigation(request):
     return JsonResponse(search)
 
 
+@robots_tag
 @add_cache_headers(settings.DEFAULT_TTL_SECONDS)
 def search_advanced(request):
     adv_search_form = forms.AdvSearchPagesForm()


### PR DESCRIPTION
This tells crawlers like Googlebot not to crawl the links obtained from search, which avoids the load on Solr from deep pagination. This does not prevent indexing of the actual detail or listing pages which are listed in the sitemaps and are discoverable without crawling all of the permutations of search parameters.
    
https://developers.google.com/search/docs/advanced/robots/robots_meta_tag
