### PR TITLE
Update Data Visualizations link text in left nav

### DIFF
--- a/loc/templates/site_base_alt.html
+++ b/loc/templates/site_base_alt.html
@@ -8,7 +8,7 @@
       <li><a href="{% url 'chronam_about' %}">About Chronicling America</a></li>
       <li><a href="{% url 'chronam_about_api' %}">About the Site and API</a></li>
       <li><a href="https://www.loc.gov/rr/news/topics/topics.html">Recommended Topics</a></li>
-      <li><a href="https://www.loc.gov/ndnp/data-visualizations/">Chronicling America Data Visualizations</a></li>
+      <li><a href="https://www.loc.gov/ndnp/data-visualizations/">Maps and Visualizations</a></li>
       <li><a href="{% url 'chronam_help' %}">Help</a></li>
     </ul>
   </div>


### PR DESCRIPTION
This change will update the link text from "Chronicling America Data Visualizations" to "Maps and Visualizations" in left navigation menu. Change requested by the LC NDNP steering committee.