### PR TITLE
GitHub Action: Avoid duplicate runs and missing runs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,11 @@
 # This GitHub Action assumes that the repo contains a valid .pre-commit-config.yaml file.
 # Using pre-commit.ci is even better that using GitHub Actions for pre-commit.
 name: pre-commit
-on: [push]
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As [discussed here](https://github.com/LibraryOfCongress/chronam/pull/251#pullrequestreview-1188579381), these changes will enable Actions to run on new pull requests like #262 and #263