### PR TITLE
Fix typos in Python files

### DIFF
--- a/core/batch_loader.py
+++ b/core/batch_loader.py
@@ -10,22 +10,22 @@ import re
 import shutil
 import tempfile
 import time
-import urllib2
-import urlparse
 from datetime import datetime
 
 import simplejson as json
+import urllib2
+import urlparse
 from django.conf import settings
 from django.core import management
 from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Q
 from lxml import etree
-from solr import SolrConnection
 
 from chronam.core import models
 from chronam.core.models import OCR, Awardee, Batch, Issue, LoadBatchEvent, Page, Title
 from chronam.core.ocr_extractor import ocr_extractor
+from solr import SolrConnection
 
 # some xml namespaces used in batch metadata
 ns = {
@@ -542,14 +542,13 @@ class BatchLoaderException(RuntimeError):
 
 
 def dmd_mods(doc, dmdid):
-    """a helper that returns mods inside a dmdSec with a given ID
-    """
+    """a helper that returns mods inside a dmdSec with a given ID"""
     xpath = './/mets:dmdSec[@ID="%s"]/descendant::mods:mods' % dmdid
     return doc.xpath(xpath, namespaces=ns)[0]
 
 
 def get_dimensions(doc, admid):
-    """return length, width for an image from techincal metadata with a given
+    """return length, width for an image from technical metadata with a given
     admid
     """
     xpath = './/mets:techMD[@ID="%s"]/mets:mdWrap/mets:xmlData/mix:mix/mix:ImagingPerformanceAssessment/mix:SpatialMetrics/%s'

--- a/core/holding_loader.py
+++ b/core/holding_loader.py
@@ -74,7 +74,7 @@ class HoldingLoader:
             return None
 
     def _get_related_inst_code(self, inst_code):
-        """ Match the institutional code or record an error."""
+        """Match the institutional code or record an error."""
         try:
             inst = models.Institution.objects.get(code=inst_code)
             return inst
@@ -84,7 +84,7 @@ class HoldingLoader:
             return None
 
     def _extract_holdings_type(self, record):
-        """ Extract holdings type from 007 field & 856 $u field. """
+        """Extract holdings type from 007 field & 856 $u field."""
         h856u = _extract(record, "856", "u")
         if h856u and h856u.startswith("http"):
             h_type = "Online Resource"
@@ -95,7 +95,7 @@ class HoldingLoader:
     def _parse_date(self, f008):
         """
         Parse date takes the f008 field and pulls out the date.
-        This is shared funciton for both formats (xml & tsv) that holdings
+        This is shared function for both formats (xml & tsv) that holdings
         come in.
         """
         date = None

--- a/core/index.py
+++ b/core/index.py
@@ -7,10 +7,10 @@ from django.core.paginator import InvalidPage, Page, Paginator
 from django.db import reset_queries
 from django.db.models import Prefetch
 from more_itertools.more import sliced
-from solr import SolrConnection
 
 from chronam.core import models
 from chronam.core.title_loader import _normal_lccn
+from solr import SolrConnection
 
 LOGGER = logging.getLogger(__name__)
 
@@ -331,7 +331,7 @@ def get_solr_request_params_from_query(query):
 
 
 def execute_solr_query(query, fields, sort, sort_order, rows, start):
-    # default arg_separator - underscore wont work if fields to facet on
+    # default arg_separator - underscore won't work if fields to facet on
     # themselves have underscore in them
     solr = SolrConnection(settings.SOLR)  # TODO: maybe keep connection around?
     solr_response = solr.query(
@@ -586,8 +586,7 @@ def index_missing_pages():
 
 
 def index_pages(only_missing=False):
-    """index all the pages that are modeled in the database
-    """
+    """index all the pages that are modeled in the database"""
     solr = SolrConnection(settings.SOLR)
 
     page_qs = models.Page.objects.order_by("pk")

--- a/core/management/commands/flickr.py
+++ b/core/management/commands/flickr.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import urllib
+
 from urlparse import urlparse
 
 from chronam.core.models import FlickrUrl, Page
@@ -14,8 +15,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Command(LoggingCommand):
-    args = '<flickr_key>'
-    help = 'load links for content that has been pushed to flickr.'  # NOQA: A003
+    args = "<flickr_key>"
+    help = "load links for content that has been pushed to flickr."  # NOQA: A003
 
     def handle(self, key, **options):
         LOGGER.debug("looking for chronam page content on flickr")
@@ -31,7 +32,7 @@ class Command(LoggingCommand):
                 self.stderr.write("page for %s not found" % chronam_url)
                 continue
 
-            # create the FlickrUrl attached to the apprpriate page
+            # create the FlickrUrl attached to the appropriate page
             f, created = FlickrUrl.objects.get_or_create(value=flickr_url, page=page)
             if created:
                 create_count += 1
@@ -44,41 +45,38 @@ class Command(LoggingCommand):
 
 
 def photos_in_set(key, set_id):
-    """A generator for all the photos in a set.
-    """
+    """A generator for all the photos in a set."""
     u = (
-        'https://api.flickr.com/services/rest/?method=flickr.photosets.getPhotos&api_key=%s&photoset_id=%s&format=json&nojsoncallback=1'
+        "https://api.flickr.com/services/rest/?method=flickr.photosets.getPhotos&api_key=%s&photoset_id=%s&format=json&nojsoncallback=1"
         % (key, set_id)
     )
     photos = json.loads(urllib.urlopen(u).read())
-    for p in photos['photoset']['photo']:
-        yield photo(key, p['id'])
+    for p in photos["photoset"]["photo"]:
+        yield photo(key, p["id"])
 
 
 def photo(key, photo_id):
-    """Return JSON for a given photo.
-    """
+    """Return JSON for a given photo."""
     u = (
-        'https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&api_key=%s&photo_id=%s&format=json&nojsoncallback=1'
+        "https://api.flickr.com/services/rest/?method=flickr.photos.getInfo&api_key=%s&photo_id=%s&format=json&nojsoncallback=1"
         % (key, photo_id)
     )
     return json.loads(urllib.urlopen(u).read())
 
 
 def flickr_url(photo):
-    for url in photo['photo']['urls']['url']:
-        if url['type'] == 'photopage':
-            return url['_content']
+    for url in photo["photo"]["urls"]["url"]:
+        if url["type"] == "photopage":
+            return url["_content"]
     return None
 
 
 def chronam_url(photo):
-    """Tries to find a chronam link in the photo metadata
-    """
+    """Tries to find a chronam link in the photo metadata"""
     # libraryofcongress photos are uploaded with a machinetag
-    for tag in photo['photo']['tags']['tag']:
-        if 'chroniclingamerica.loc.gov' in tag['raw']:
-            return tag['raw'].replace('dc:identifier=', '')
+    for tag in photo["photo"]["tags"]["tag"]:
+        if "chroniclingamerica.loc.gov" in tag["raw"]:
+            return tag["raw"].replace("dc:identifier=", "")
 
     # some other photos might have a link in the textual description
     m = re.search(r'"(https?://chroniclingamerica.loc.gov/.+?)"', photo["photo"]["description"]["_content"])

--- a/core/management/commands/load_holdings.py
+++ b/core/management/commands/load_holdings.py
@@ -16,11 +16,11 @@ LOGGER = logging.getLogger(__name__)
 
 class Command(LoggingCommand):
     help = "Load a holdings records after title records are all loaded"  # NOQA: A003
-    args = '<location of holdings directory>'
+    args = "<location of holdings directory>"
 
     bib_in_settings = validate_bib_dir()
     if bib_in_settings:
-        default_location = bib_in_settings + '/holdings'
+        default_location = bib_in_settings + "/holdings"
     else:
         default_location = None
 
@@ -30,16 +30,16 @@ class Command(LoggingCommand):
             LOGGER.error("There is no valid holdings source folder defined.")
             set_holdings = [
                 'To load holdings - Add a folder called "holdings"',
-                'to the bib directory that is set in settings',
-                'or pass the location of holdings as an arguement to the loader.',
+                "to the bib directory that is set in settings",
+                "or pass the location of holdings as an argument to the loader.",
             ]
-            LOGGER.error(' '.join(set_holdings))
+            LOGGER.error(" ".join(set_holdings))
             return
 
         # First we want to make sure that our material types are up to date
         material_types = models.MaterialType.objects.all()
         [m.delete() for m in material_types]
-        management.call_command('loaddata', 'material_types.json')
+        management.call_command("loaddata", "material_types.json")
 
         holding_loader = HoldingLoader()
         holding_loader.main(holdings_source)

--- a/core/management/commands/load_titles.py
+++ b/core/management/commands/load_titles.py
@@ -13,12 +13,12 @@ from . import LoggingCommand
 
 class Command(LoggingCommand):
     help = "Load a marcxml file of title records"  # NOQA: A003
-    args = '<location of marcxml>'
+    args = "<location of marcxml>"
     option_list = LoggingCommand.option_list + (
         make_option(
-            '--skip-index',
-            action='store_true',
-            dest='skip_index',
+            "--skip-index",
+            action="store_true",
+            dest="skip_index",
             default=False,
             help="\
                 Skip the index process. Use this if you call this from \
@@ -51,10 +51,10 @@ class Command(LoggingCommand):
         return results
 
     def add_results(self, results):
-        '''
+        """
         The add results functions adds the new set of results to the
-        running totals for the current run & retuns the new results set.
-        '''
+        running totals for the current run & returns the new results set.
+        """
         self.total_processed += results[0]
         self.total_created += results[1]
         self.total_updated += results[2]
@@ -84,7 +84,7 @@ class Command(LoggingCommand):
         self.stdout.write("TOTAL TIME: %s" % str(total_time))
 
     def handle(self, marc_xml_source, *args, **options):
-        skip_index = options['skip_index']
+        skip_index = options["skip_index"]
 
         # check if arg passed is a file or a directory of files
         if os.path.isdir(marc_xml_source):

--- a/core/management/commands/pull_titles.py
+++ b/core/management/commands/pull_titles.py
@@ -15,32 +15,32 @@ LOGGER = logging.getLogger(__name__)
 
 class Command(LoggingCommand):
     help = "Retrieve a fresh pull of titles from OCLC"  # NOQA: A003
-    args = ''
+    args = ""
     # TODO: Remove default from lccn
     option_list = LoggingCommand.option_list + (
         make_option(
-            '-l',
-            '--lccn',
-            action='store',
-            dest='lccn',
+            "-l",
+            "--lccn",
+            action="store",
+            dest="lccn",
             default=None,
             help="Pass a specific lccn to pull down updates from Worldcat.",
         ),
         make_option(
-            '-o',
-            '--oclc',
-            action='store',
-            dest='oclc',
+            "-o",
+            "--oclc",
+            action="store",
+            dest="oclc",
             default=None,
             help="Pass an oclc number when you pass an lccn.",
         ),
         make_option(
-            '-p',
-            '--path',
-            action='store',
-            dest='path',
-            default='/worldcat_titles/',
-            help="Path var that is appeneded to settings.BIB_STORAGE to save to",
+            "-p",
+            "--path",
+            action="store",
+            dest="path",
+            default="/worldcat_titles/",
+            help="Path var that is appended to settings.BIB_STORAGE to save to",
         ),
     )
 
@@ -53,17 +53,17 @@ class Command(LoggingCommand):
         return start, end
 
     def handle(self, **options):
-        lccn = options['lccn']
-        oclc = options['oclc']
-        path = options['path']
+        lccn = options["lccn"]
+        oclc = options["oclc"]
+        path = options["path"]
 
         if lccn:
-            start, end = self.run_pull(path + '/lccn/', lccn, oclc)
+            start, end = self.run_pull(path + "/lccn/", lccn, oclc)
             if start and end:
                 LOGGER.info("lccn: %s, oclc: %s" % (lccn, oclc))
         else:
             LOGGER.info("started pulling titles from OCLC.")
-            start, end = self.run_pull(path + 'bulk/')
+            start, end = self.run_pull(path + "bulk/")
             LOGGER.info("finished pulling titles from OCLC.")
             LOGGER.info("start time: %s" % start)
             LOGGER.info("end time: %s" % end)

--- a/core/models.py
+++ b/core/models.py
@@ -8,10 +8,10 @@ import shutil
 import tarfile
 import textwrap
 import time
-import urlparse
-from cStringIO import StringIO
 from urllib import quote, url2pathname
 
+import urlparse
+from cStringIO import StringIO
 from django.conf import settings
 from django.core import urlresolvers
 from django.core.urlresolvers import reverse
@@ -324,7 +324,7 @@ class Title(models.Model):
         return False
 
     # TODO: if we took two passes through the title data during title
-    # loading we could link up the Title objects explictly with each
+    # loading we could link up the Title objects explicitly with each
     # other. This would be 'doing the right thing' from a rdbms perspective
     #
     # For the time being we just extract and store the links, with their
@@ -386,7 +386,7 @@ class Title(models.Model):
 
     def __unicode__(self):
         # TODO: should edition info go in here if present?
-        return u"%s (%s) %s-%s" % (
+        return "%s (%s) %s-%s" % (
             self.display_name,
             self.place_of_publication,
             self.start_year,
@@ -844,7 +844,7 @@ class Page(models.Model):
         return None
 
     def __unicode__(self):
-        parts = [u"%s" % self.issue.title]
+        parts = ["%s" % self.issue.title]
         # little hack to get django's datetime support for stftime
         # when the year is < 1900
         parts.append(strftime(self.issue.date_issued, "%B %d, %Y"))
@@ -853,7 +853,7 @@ class Page(models.Model):
         if self.section_label:
             parts.append(self.section_label)
         parts.append("Image %s" % self.sequence)
-        return u", ".join(parts)
+        return ", ".join(parts)
 
     class Meta:
         ordering = ("sequence",)
@@ -893,7 +893,7 @@ class Place(models.Model):
     longitude = models.FloatField(null=True)
 
     def __unicode__(self):
-        return u"%s, %s, %s" % (self.city, self.county, self.state)
+        return "%s, %s, %s" % (self.city, self.county, self.state)
 
     class Meta:
         ordering = ("name",)
@@ -932,7 +932,7 @@ class PageNote(models.Model):
     page = models.ForeignKey("Page", related_name="notes")
 
     def __unicode__(self):
-        return u"type: %s label: %s text: %s" % (self.type, self.label, self.text)
+        return "type: %s label: %s text: %s" % (self.type, self.label, self.text)
 
     class Meta:
         ordering = ("text",)
@@ -945,7 +945,7 @@ class IssueNote(models.Model):
     issue = models.ForeignKey("Issue", related_name="notes")
 
     def __unicode__(self):
-        return u"type: %s label: %s text: %s" % (self.type, self.label, self.text)
+        return "type: %s label: %s text: %s" % (self.type, self.label, self.text)
 
     class Meta:
         ordering = ("text",)
@@ -1006,7 +1006,7 @@ class Holding(models.Model):
             return [self.description]
 
     def __unicode__(self):
-        return u"%s - %s - %s" % (self.institution.name, self.type, self.description)
+        return "%s - %s - %s" % (self.institution.name, self.type, self.description)
 
     class Meta:
         ordering = ("institution",)
@@ -1135,7 +1135,7 @@ class Institution(models.Model):
     created = models.DateTimeField(auto_now_add=True)
 
     def __unicode__(self):
-        return u"%s, %s, %s" % (self.name, self.city, self.state)
+        return "%s, %s, %s" % (self.name, self.city, self.state)
 
     class Meta:
         ordering = ("name",)
@@ -1188,8 +1188,7 @@ class OcrDump(models.Model):
 
     @classmethod
     def new_from_batch(klass, batch):
-        """Does the work of creating a new OcrDump based on a Batch
-        """
+        """Does the work of creating a new OcrDump based on a Batch"""
         dump = OcrDump(batch=batch)
         event = LoadBatchEvent(batch_name=batch.name, message="starting OCR dump")
         event.save()
@@ -1305,12 +1304,11 @@ class OcrDump(models.Model):
         self.size = os.path.getsize(self.path)
 
     def _calculate_sha1(self):
-        """looks at the dump file and calculates the sha1 digest and stores it
-        """
+        """looks at the dump file and calculates the sha1 digest and stores it"""
         f = open(self.path)
         sha1 = hashlib.sha1()
         while True:
-            buff = f.read(2 ** 16)
+            buff = f.read(2**16)
             if not buff:
                 break
             sha1.update(buff)

--- a/core/tests/browse_tests.py
+++ b/core/tests/browse_tests.py
@@ -1,20 +1,21 @@
 import os
 
-from django.test import TestCase
-from django.db import connection
 from django.conf import settings
+from django.db import connection
+from django.test import TestCase
 
+from chronam.core.batch_loader import Batch, BatchLoader
 from chronam.core.index import get_page_text
-from chronam.core.utils.utils import _get_tip
-from chronam.core.batch_loader import BatchLoader, Batch
 from chronam.core.models import Title
+from chronam.core.utils.utils import _get_tip
 
 
 class BrowseTests(TestCase):
     """
     Tests related to core/views/browse.py
     """
-    fixtures = ['countries.json', 'languages.json', 'awardee.json']
+
+    fixtures = ["countries.json", "languages.json", "awardee.json"]
 
     def test_words_redirect(self):
         """
@@ -30,7 +31,7 @@ class BrowseTests(TestCase):
         query parameters should be preserved for page
         ex: /lccn/sn85066387/1907-03-17/ed-1/seq-4/;words=foo?bar=ham
         should redirect to /lccn/sn85066387/1907-03-17/ed-1/seq-4/?bar=ham#words=foo
-        This is needed so that campain codes work properly
+        This is needed so that campaign codes work properly
         """
         r = self.client.get("/lccn/sn83045396/1911-09-17/ed-1/seq-12/;words=foo?bar=ham")
         self.assertEquals(r.status_code, 302)
@@ -42,9 +43,8 @@ class BrowseTests(TestCase):
             cursor.execute("SHOW COLUMNS FROM core_languagetext")
             rows = cursor.fetchall()
             for row in rows:
-                if row[0] == 'text':
-                    self.fail("core_languagetext.text should not exist. "
-                              "Did you run the migrations?")
+                if row[0] == "text":
+                    self.fail("core_languagetext.text should not exist. " "Did you run the migrations?")
 
     def test_getting_text_from_solr_utah(self):
         """
@@ -52,21 +52,21 @@ class BrowseTests(TestCase):
         First creates a page object 'page' with _get_tip()
         then uses it as an argument to get_page_text()
         """
-        batch_dir = os.path.join(settings.BATCH_STORAGE, 'batch_uuml_thys_ver01')
+        batch_dir = os.path.join(settings.BATCH_STORAGE, "batch_uuml_thys_ver01")
         self.assertTrue(os.path.isdir(batch_dir))
         loader = BatchLoader(process_ocr=True)
         batch = loader.load_batch(batch_dir)
-        self.assertEqual(batch.name, 'batch_uuml_thys_ver01')
-        title, issue, page = _get_tip('sn83045396', '1911-09-17', 1, 1)
+        self.assertEqual(batch.name, "batch_uuml_thys_ver01")
+        title, issue, page = _get_tip("sn83045396", "1911-09-17", 1, 1)
         text = get_page_text(page)
         self.assertIn("Uc nice at tlio slate fair track", text[0])
         self.assertIn("PAGES FIVE CENTS", text[0])
-        self.assertIn('gBter ho had left the grounds that', text[0])
+        self.assertIn("gBter ho had left the grounds that", text[0])
 
         # purge the batch and make sure it's gone from the db
-        loader.purge_batch('batch_uuml_thys_ver01')
+        loader.purge_batch("batch_uuml_thys_ver01")
         self.assertEqual(Batch.objects.all().count(), 0)
-        self.assertEqual(Title.objects.get(lccn='sn83045396').has_issues, False)
+        self.assertEqual(Title.objects.get(lccn="sn83045396").has_issues, False)
 
     def test_getting_text_from_solr_slovenia(self):
         """
@@ -74,17 +74,17 @@ class BrowseTests(TestCase):
         First creates a page object 'page' with _get_tip()
         then uses it as an argument to get_page_text()
         """
-        batch_dir = os.path.join(settings.BATCH_STORAGE, 'batch_iune_oriole_ver01')
+        batch_dir = os.path.join(settings.BATCH_STORAGE, "batch_iune_oriole_ver01")
         self.assertTrue(os.path.isdir(batch_dir))
         loader = BatchLoader(process_ocr=True)
         batch = loader.load_batch(batch_dir)
-        self.assertEqual(batch.name, 'batch_iune_oriole_ver01')
-        title, issue, page = _get_tip('sn83045377', '1906-03-01', 1, 1)
+        self.assertEqual(batch.name, "batch_iune_oriole_ver01")
+        title, issue, page = _get_tip("sn83045377", "1906-03-01", 1, 1)
         text = get_page_text(page)
         self.assertIn("Od Mizo in dale", text[0])
         self.assertIn("To je preecj inoettii tobak! Marsi", text[0])
 
         # purge the batch and make sure it's gone from the db
-        loader.purge_batch('batch_iune_oriole_ver01')
+        loader.purge_batch("batch_iune_oriole_ver01")
         self.assertEqual(Batch.objects.all().count(), 0)
-        self.assertEqual(Title.objects.get(lccn='sn83045377').has_issues, False)
+        self.assertEqual(Title.objects.get(lccn="sn83045377").has_issues, False)

--- a/core/tests/json_tests.py
+++ b/core/tests/json_tests.py
@@ -9,14 +9,14 @@ from chronam.core import models as m
 
 
 class JsonTests(TestCase):
-    fixtures = ['batch.json', "awardee.json"]
+    fixtures = ["batch.json", "awardee.json"]
 
     def test_speedups(self):
-        # simplejson needs to have c bits comiled to be fast enough
+        # simplejson needs to have c bits compiled to be fast enough
         self.assertTrue(json._speedups)
 
     def test_batch(self):
-        b = m.Batch.objects.get(name='batch_curiv_ahwahnee_ver01')
+        b = m.Batch.objects.get(name="batch_curiv_ahwahnee_ver01")
         j = b.json()
         x = json.loads(j)
-        self.assertEqual(x['name'], 'batch_curiv_ahwahnee_ver01')
+        self.assertEqual(x["name"], "batch_curiv_ahwahnee_ver01")

--- a/core/title_pull.py
+++ b/core/title_pull.py
@@ -11,86 +11,86 @@ from worldcat.util.extract import extract_elements
 LOGGER = logging.getLogger(__name__)
 
 WSKEY = settings.WORLDCAT_KEY
-sortkeys = 'Date,,0'
-recordschema = 'info:srw/schema/1/marcxml'
-recordpacking = 'xml'
-servicelevel = 'full'
-frbrgrouping = 'off'
+sortkeys = "Date,,0"
+recordschema = "info:srw/schema/1/marcxml"
+recordpacking = "xml"
+servicelevel = "full"
+frbrgrouping = "off"
 MAX_RECORDS = 50
 raw_query = 'srw.pc any "y" and srw.mt any "newspaper"'  # and srw.cp exact "united states"
 
 COUNTRIES = (
-    'united states',
-    'puerto rico',
-    'virgin island*',
-    'guam',
-    '*northern mariana*',
-    'american samoa',
+    "united states",
+    "puerto rico",
+    "virgin island*",
+    "guam",
+    "*northern mariana*",
+    "american samoa",
     # According to MARC states are also countries
-    'Alabama',
-    'Alaska',
-    'Arizona',
-    'Arkansas',
-    'California',
-    'Colorado',
-    'Connecticut',
-    'Delaware',
-    'Florida',
-    'Georgia',
-    'Hawaii',
-    'Idaho',
-    'Illinois',
-    'Indiana',
-    'Iowa',
-    'Kansas',
-    'Kentucky',
-    'Louisiana',
-    'Maine',
-    'Maryland',
-    'Massachusetts',
-    'Michigan',
-    'Minnesota',
-    'Mississippi',
-    'Missouri',
-    'Montana',
-    'Nebraska',
-    'Nevada',
-    'New Hampshire',
-    'New Jersey',
-    'New Mexico',
-    'New York',
-    'North Carolina',
-    'North Dakota',
-    'Ohio',
-    'Oklahoma',
-    'Oregon',
-    'Pennsylvania',
-    'Rhode Island',
-    'South Carolina',
-    'South Dakota',
-    'Tennessee',
-    'Texas',
-    'Utah',
-    'Vermont',
-    'Virginia',
-    'Washington',
-    'West Virginia',
-    'Wisconsin',
-    'Wyoming',
+    "Alabama",
+    "Alaska",
+    "Arizona",
+    "Arkansas",
+    "California",
+    "Colorado",
+    "Connecticut",
+    "Delaware",
+    "Florida",
+    "Georgia",
+    "Hawaii",
+    "Idaho",
+    "Illinois",
+    "Indiana",
+    "Iowa",
+    "Kansas",
+    "Kentucky",
+    "Louisiana",
+    "Maine",
+    "Maryland",
+    "Massachusetts",
+    "Michigan",
+    "Minnesota",
+    "Mississippi",
+    "Missouri",
+    "Montana",
+    "Nebraska",
+    "Nevada",
+    "New Hampshire",
+    "New Jersey",
+    "New Mexico",
+    "New York",
+    "North Carolina",
+    "North Dakota",
+    "Ohio",
+    "Oklahoma",
+    "Oregon",
+    "Pennsylvania",
+    "Rhode Island",
+    "South Carolina",
+    "South Dakota",
+    "Tennessee",
+    "Texas",
+    "Utah",
+    "Vermont",
+    "Virginia",
+    "Washington",
+    "West Virginia",
+    "Wisconsin",
+    "Wyoming",
 )
 
 # operate map is used in passing the operator to the output file.
-OPERATOR_MAP = {'=': 'e', '<=': 'lte', '>=': 'gte', '>': 'gt', '<': 'lt'}
+OPERATOR_MAP = {"=": "e", "<=": "lte", ">=": "gte", ">": "gt", "<": "lt"}
 
 
 def str_value(value):
-    '''
+    """
     Turn the value into at least a 4 digit string.
     This is used in the naming of files.
-    '''
+    """
     str_value = str(value)
     while len(str_value) < 4:
-        str_value = '0' + str_value
+        str_value = "0" + str_value
     return str_value
 
 
@@ -107,7 +107,7 @@ class TitlePuller(object):
     year_breaks = []
 
     def generate_year_dict(self, start=None, end=None):
-        '''
+        """
         Generate a list of years to break up the query. OCLC API queries
         between 1000 and 2030 if not defined. Our main use case is after 1800.
         Since we break up our requests by year, we are starting
@@ -125,7 +125,7 @@ class TitlePuller(object):
         are ignored. This is so the user has control & extra records are
         not added. It should be noted that a date such as 19uu will be
         indexed as 1900 & 195u will be indexed as 1950.
-        '''
+        """
 
         year_and_action = {}
 
@@ -134,25 +134,25 @@ class TitlePuller(object):
         # to start & end values.
         if not start or not end:
             # Numbers are converted to strings, because we want 0000, not 0.
-            special_yr_cases = ['0000', '1000']
+            special_yr_cases = ["0000", "1000"]
         else:
             special_yr_cases = []
 
         if start:
-            year_and_action[str(start)] = '='
+            year_and_action[str(start)] = "="
         else:
             start = 1800
-            year_and_action[str(start)] = '<='
+            year_and_action[str(start)] = "<="
 
         if end:
-            year_and_action[str(end)] = '='
+            year_and_action[str(end)] = "="
         else:
             now = datetime.datetime.now()
             end = now.year
-            year_and_action[str(end)] = '>='
+            year_and_action[str(end)] = ">="
 
         for year in range(start + 1, end) + special_yr_cases:
-            year_and_action[str(year)] = '='
+            year_and_action[str(year)] = "="
 
         # example if start & end are passed:
         # {'1949': '=', '1951': '=', '1950': '=', '1952': '='}
@@ -162,7 +162,7 @@ class TitlePuller(object):
         return year_and_action
 
     def add_to_query(self, oclc_field, value, relationship, query=None):
-        '''
+        """
         Add additional values to the base query
         For example, this:
         self.add_to_query(query, 'srw.la', 'spa', 'exact')
@@ -174,17 +174,17 @@ class TitlePuller(object):
 
         More info on indexes to query:
         http://oclc.org/developer/documentation/worldcat-search-api/complete-list-indexes
-        '''
+        """
         new_query = '%s %s "%s"' % (oclc_field, relationship, value)
         if query:
-            new_query = '%s and %s' % (query, new_query)
+            new_query = "%s and %s" % (query, new_query)
         return new_query
 
     def generate_srurequest(self, query):
-        '''
+        """
         Generates the SRURequest used to query OCLC API.
         Most of the values are static, except for query.
-        '''
+        """
 
         LOGGER.debug("The query for OCLC is '%s'" % query)
         bib_rec = SRURequest(
@@ -210,11 +210,11 @@ class TitlePuller(object):
         end=None,
         totals_only=False,
     ):
-        '''
+        """
         Generate request(s) is a function that generates a set of requests
         to be executed against the OCLC API. A set of requests can be
         just one request, example an lccn, or it can be a larger title pull.
-        '''
+        """
         # create an empty list of bib_recs_to_execute.
         bibs_to_req = []
         # if this request is lccn or oclc specific, create 1 request
@@ -222,9 +222,9 @@ class TitlePuller(object):
         if lccn or oclc:
 
             if lccn:
-                query = self.add_to_query('srw.dn', lccn, 'exact')
+                query = self.add_to_query("srw.dn", lccn, "exact")
             elif oclc:
-                query = self.add_to_query('srw.no', oclc, 'exact')
+                query = self.add_to_query("srw.no", oclc, "exact")
 
             request = self.generate_srurequest(query)
             lccn_count = self.initial_total_count(request)
@@ -234,7 +234,7 @@ class TitlePuller(object):
             grand_total = 0
             for country in countries:
                 total = 0
-                query = self.add_to_query('srw.cp', country, 'exact', raw_query)
+                query = self.add_to_query("srw.cp", country, "exact", raw_query)
 
                 # We want to force this to pass through the year dividing
                 # pass below.
@@ -252,11 +252,11 @@ class TitlePuller(object):
 
                 if request_able == 0:
                     # There is no valid requests at all. So, we exit.
-                    LOGGER.warning('No records returned for: %s' % (country))
+                    LOGGER.warning("No records returned for: %s" % (country))
                 elif request_able:
                     # If we can pull the whole country at once, we will
                     # otherwise we break it up into multiple requests.
-                    bibs_to_req.append((cntry_req, request_able, (country.strip('*'), 'all-yrs', '=')))
+                    bibs_to_req.append((cntry_req, request_able, (country.strip("*"), "all-yrs", "=")))
                     total += request_able
                 else:
                     # generate split requests by year
@@ -266,7 +266,7 @@ class TitlePuller(object):
 
                     for year in sorted(year_dict.iterkeys()):
                         operator = year_dict[year]
-                        query = self.add_to_query('srw.yr', year, operator, base_query)
+                        query = self.add_to_query("srw.yr", year, operator, base_query)
                         yr_request = self.generate_srurequest(query)
                         yr_count = self.initial_total_count(yr_request)
                         yr_request_able = self.check_for_doable_bulk_request(yr_count)
@@ -277,29 +277,29 @@ class TitlePuller(object):
 
                         if yr_request_able or year == str(datetime.datetime.now().year):
                             bibs_to_req.append(
-                                (yr_request, yr_request_able, (country.strip('*'), year, operator))
+                                (yr_request, yr_request_able, (country.strip("*"), year, operator))
                             )
                             total += yr_request_able
                         else:
                             LOGGER.warning("There is a problem with request. Exiting.")
-                            LOGGER.warning('yr_request: %s' % yr_request)
-                            LOGGER.warning('yr_request_able: %s' % yr_request_able)
-                            LOGGER.warning('country: %s' % country.strip('*'))
-                            LOGGER.warning('year: %s' % year)
-                            LOGGER.warning('operator: %s' % operator)
+                            LOGGER.warning("yr_request: %s" % yr_request)
+                            LOGGER.warning("yr_request_able: %s" % yr_request_able)
+                            LOGGER.warning("country: %s" % country.strip("*"))
+                            LOGGER.warning("year: %s" % year)
+                            LOGGER.warning("operator: %s" % operator)
 
                             continue
 
                 grand_total += total
-            LOGGER.info('GRAND TOTAL: %s' % (grand_total))
+            LOGGER.info("GRAND TOTAL: %s" % (grand_total))
 
         return bibs_to_req
 
-    def grab_content(self, save_path, bib_requests, search_name='ndnp'):
-        '''
+    def grab_content(self, save_path, bib_requests, search_name="ndnp"):
+        """
         Loops over all requests, executes request & saves response
         to the designated 'save_path'.
-        '''
+        """
         # Run each request and save content.
         if not bib_requests:
             return
@@ -319,7 +319,7 @@ class TitlePuller(object):
                 bib_resp = bib_request.get_response()
                 # identify the xml field of next record number from the xml
                 next_record = extract_elements(
-                    bib_request.response, element='{http://www.loc.gov/zing/srw/}nextRecordPosition'
+                    bib_request.response, element="{http://www.loc.gov/zing/srw/}nextRecordPosition"
                 )
 
                 # grab the text from next_record to get the actual value
@@ -347,23 +347,23 @@ class TitlePuller(object):
 
                 name_components = []
                 for i in components:
-                    i = i.replace(' ', '-')
+                    i = i.replace(" ", "-")
                     if i in OPERATOR_MAP:
                         i = OPERATOR_MAP[i]
                     name_components.append(i)
 
-                batch_name = '_'.join(name_components)
+                batch_name = "_".join(name_components)
 
-                filename = '_'.join((search_name, batch_name, str_value(start), str_value(end))) + '.xml'
+                filename = "_".join((search_name, batch_name, str_value(start), str_value(end))) + ".xml"
 
                 if counter == 1 and len(bib_requests) > 1:
-                    LOGGER.info('Batch: %s = %s total' % (filename, total))
+                    LOGGER.info("Batch: %s = %s total" % (filename, total))
 
-                file_location = save_path + '/' + filename
+                file_location = save_path + "/" + filename
 
                 save_file = open(file_location, "w")
                 decoded_data = bib_resp.data.decode("utf-8")
-                save_file.write(decoded_data.encode('ascii', 'xmlcharrefreplace'))
+                save_file.write(decoded_data.encode("ascii", "xmlcharrefreplace"))
                 save_file.close()
                 files_saved += 1
 
@@ -377,17 +377,17 @@ class TitlePuller(object):
         return files_saved
 
     def initial_total_count(self, bib_req):
-        '''
+        """
         This is used to access the quality of results returned.
-        '''
+        """
         bib_req.get_response()
-        _total = extract_elements(bib_req.response, element='{http://www.loc.gov/zing/srw/}numberOfRecords')
+        _total = extract_elements(bib_req.response, element="{http://www.loc.gov/zing/srw/}numberOfRecords")
         return _total[0].text
 
     def check_for_doable_bulk_request(self, test_totals):
-        '''
+        """
         The API could misfire when requesting more than 10k, so we make sure that are requests aren't that large.
-        '''
+        """
         if not test_totals:
             LOGGER.error(
                 "The total is %s but should be a integer. Check the query to make sure API isn't broken."
@@ -395,7 +395,7 @@ class TitlePuller(object):
             )
             return None
         else:
-            # check that the request is managable.
+            # check that the request is manageable.
             # requests over 10000 records will cause failure on the OCLC side
             total = int(test_totals)
             if total < 10000:
@@ -405,7 +405,7 @@ class TitlePuller(object):
         return None
 
     def run(self, save_path, lccn=None, oclc=None, start=None, end=None, countries=COUNTRIES):
-        '''
+        """
         Function that runs a search against the WorldCat Search API
 
         The default query is:
@@ -415,18 +415,18 @@ class TitlePuller(object):
         If you pass a string as the query, then it will over ride
         and pull for that query.
         Response is stored in data if no argument is passed.
-        '''
+        """
         # Create directory if it doesn't exist
         if not os.path.exists(save_path):
             try:
                 os.makedirs(save_path)
             except OSError:
-                LOGGER.exception('Issue creating the directory %s.' % save_path)
+                LOGGER.exception("Issue creating the directory %s." % save_path)
                 sys.exit()
         else:
             # Make sure the directory is empty
             if len([f for f in os.listdir(save_path) if os.path.isfile(f)]):
-                LOGGER.exception('Destination directory %s is not empty.' % save_path)
+                LOGGER.exception("Destination directory %s is not empty." % save_path)
                 sys.exit()
 
         files_saved = 0

--- a/core/utils/utils.py
+++ b/core/utils/utils.py
@@ -60,7 +60,7 @@ class HTMLCalendar(calendar.Calendar):
                 _class = "single"
                 lccn, date_issued, edition = issues[0]
                 kw = dict(lccn=lccn, date=date_issued, edition=edition)
-                url = urlresolvers.reverse('chronam_issue_pages', kwargs=kw)
+                url = urlresolvers.reverse("chronam_issue_pages", kwargs=kw)
                 _day = """<a href="%s">%s</a>""" % (url, day)
             elif count > 1:
                 _class = "multiple"
@@ -68,7 +68,7 @@ class HTMLCalendar(calendar.Calendar):
                 _day += "<ul class='unstyled'>"
                 for lccn, date_issued, edition in issues:
                     kw = dict(lccn=lccn, date=date_issued, edition=edition)
-                    url = urlresolvers.reverse('chronam_issue_pages', kwargs=kw)
+                    url = urlresolvers.reverse("chronam_issue_pages", kwargs=kw)
                     _day += """<li><a href="%s">ed-%d</a></li>""" % (url, edition)
                 _day += "</ul>"
             else:
@@ -80,8 +80,8 @@ class HTMLCalendar(calendar.Calendar):
         """
         Return a complete week as a table row.
         """
-        s = ''.join(self.formatday(year, month, d, wd) for (d, wd) in theweek)
-        return '<tr>%s</tr>' % s
+        s = "".join(self.formatday(year, month, d, wd) for (d, wd) in theweek)
+        return "<tr>%s</tr>" % s
 
     def formatweekday(self, day):
         """
@@ -93,7 +93,7 @@ class HTMLCalendar(calendar.Calendar):
         """
         Return a header for a week as a table row.
         """
-        s = ''.join(self.formatweekday(i) for i in self.iterweekdays())
+        s = "".join(self.formatweekday(i) for i in self.iterweekdays())
         return '<tr class="daynames">%s</tr>' % s
 
     def formatmonthname(self, theyear, themonth, withyear=True):
@@ -101,9 +101,9 @@ class HTMLCalendar(calendar.Calendar):
         Return a month name as a table row.
         """
         if withyear:
-            s = '%s %s' % (calendar.month_name[themonth], theyear)
+            s = "%s %s" % (calendar.month_name[themonth], theyear)
         else:
-            s = '%s' % calendar.month_name[themonth]
+            s = "%s" % calendar.month_name[themonth]
         return '<tr><td colspan="7" class="title">%s, %s</td></tr>' % (s, theyear)
 
     def formatmonth(self, theyear, themonth, withyear=True):
@@ -115,21 +115,21 @@ class HTMLCalendar(calendar.Calendar):
         a(
             '<table border="0" cellpadding="0" cellspacing="0" class="month table table-condensed table-bordered">'
         )
-        a('\n')
+        a("\n")
         a(self.formatmonthname(theyear, themonth, withyear=withyear))
-        a('\n')
+        a("\n")
         a(self.formatweekheader())
-        a('\n')
+        a("\n")
         weeks = self.monthdays2calendar(theyear, themonth)
         while len(weeks) < 6:
             # add blank weeks so all calendars are 6 weeks long.
             weeks.append([(0, 0)] * 7)
         for week in weeks:
             a(self.formatweek(theyear, themonth, week))
-            a('\n')
-        a('</table>')
-        a('\n')
-        return ''.join(v)
+            a("\n")
+        a("</table>")
+        a("\n")
+        return "".join(v)
 
     def formatyear(self, theyear, width=4):
         """
@@ -146,10 +146,10 @@ class HTMLCalendar(calendar.Calendar):
             for m in months:
                 a('<div class="span3 calendar_month">')
                 a(self.formatmonth(theyear, m, withyear=False))
-                a('</div>')
-            a('</div>')
-        a('</div>')
-        return ''.join(v)
+                a("</div>")
+            a("</div>")
+        a("</div>")
+        return "".join(v)
 
 
 def get_page(lccn, date, edition, sequence):
@@ -212,9 +212,9 @@ def _stream_file(path, mimetype):
     if path:
         stat = os.stat(path)
         r = HttpResponse(wsgiref.util.FileWrapper(file(path)))
-        r['Content-Type'] = mimetype
-        r['Content-Length'] = stat.st_size
-        r['Last-Modified'] = http_date(stat.st_mtime)
+        r["Content-Type"] = mimetype
+        r["Content-Length"] = stat.st_size
+        r["Last-Modified"] = http_date(stat.st_mtime)
         return r
     else:
         raise Http404
@@ -222,7 +222,7 @@ def _stream_file(path, mimetype):
 
 def label(instance):
     if isinstance(instance, models.Title):
-        return u'%s (%s) %s-%s' % (
+        return "%s (%s) %s-%s" % (
             instance.display_name,
             instance.place_of_publication,
             instance.start_year,
@@ -231,20 +231,20 @@ def label(instance):
     elif isinstance(instance, models.Issue):
         parts = []
         dt = datetime_safe.new_datetime(instance.date_issued)
-        parts.append(dt.strftime('%B %d, %Y'))
+        parts.append(dt.strftime("%B %d, %Y"))
         if instance.edition_label:
-            parts.append(u"%s" % instance.edition_label)
-        return u', '.join(parts)
+            parts.append("%s" % instance.edition_label)
+        return ", ".join(parts)
     elif isinstance(instance, models.Page):
         parts = []
         if instance.section_label:
             parts.append(instance.section_label)
         if instance.number:
-            parts.append('Page %s' % instance.number)
-        parts.append('Image %s' % instance.sequence)
-        return u', '.join(parts)
+            parts.append("Page %s" % instance.number)
+        parts.append("Image %s" % instance.sequence)
+        return ", ".join(parts)
     else:
-        return u"%s" % instance
+        return "%s" % instance
 
 
 def create_crumbs(title, issue=None, date=None, edition=None, page=None):
@@ -252,17 +252,17 @@ def create_crumbs(title, issue=None, date=None, edition=None, page=None):
     crumbs.extend(
         [
             {
-                'label': label(title.name.split(":")[0]),
-                'href': urlresolvers.reverse('chronam_title', kwargs={'lccn': title.lccn}),
+                "label": label(title.name.split(":")[0]),
+                "href": urlresolvers.reverse("chronam_title", kwargs={"lccn": title.lccn}),
             }
         ]
     )
     if date and edition is not None:
         crumbs.append(
             {
-                'label': label(issue),
-                'href': urlresolvers.reverse(
-                    'chronam_issue_pages', kwargs={'lccn': title.lccn, 'date': date, 'edition': edition}
+                "label": label(issue),
+                "href": urlresolvers.reverse(
+                    "chronam_issue_pages", kwargs={"lccn": title.lccn, "date": date, "edition": edition}
                 ),
             }
         )
@@ -270,10 +270,10 @@ def create_crumbs(title, issue=None, date=None, edition=None, page=None):
     if page is not None:
         crumbs.append(
             {
-                'label': label(page),
-                'href': urlresolvers.reverse(
-                    'chronam_page',
-                    kwargs={'lccn': title.lccn, 'date': date, 'edition': edition, 'sequence': page.sequence},
+                "label": label(page),
+                "href": urlresolvers.reverse(
+                    "chronam_page",
+                    kwargs={"lccn": title.lccn, "date": date, "edition": edition, "sequence": page.sequence},
                 ),
             }
         )
@@ -296,20 +296,20 @@ def add_cache_tag(response, tag_name):
     Adds Cache-Tag header or appends to it if it already exists. This is
     useful for cloudflare so that we can purge based on the tag
 
-    only first 255 bytes will be repected
+    only first 255 bytes will be respected
 
     values must be escaped before sending
 
     see https://support.cloudflare.com/hc/en-us/articles/206596608-How-to-Purge-Cache-Using-Cache-Tags-Enterprise-only- for more information
     """
-    if response.has_header('Cache-Tag'):
-        response['Cache-Tag'] += ',%s' % tag_name
+    if response.has_header("Cache-Tag"):
+        response["Cache-Tag"] += ",%s" % tag_name
     else:
-        response['Cache-Tag'] = tag_name
+        response["Cache-Tag"] = tag_name
     return response
 
 
-VALID_JSONP_CALLBACK = re.compile(r'^[\w_]{1,100}$')
+VALID_JSONP_CALLBACK = re.compile(r"^[\w_]{1,100}$")
 
 
 def is_valid_jsonp_callback(callback):

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -2,10 +2,9 @@ import datetime
 import logging
 import os
 import re
-import urlparse
 import warnings
-from urlparse import urljoin
 
+import urlparse
 from django import forms as django_forms
 from django.conf import settings
 from django.core import urlresolvers
@@ -26,6 +25,7 @@ from django.utils import html
 from django.utils.http import urlencode
 from django.views.decorators.vary import vary_on_headers
 from sendfile import sendfile
+from urlparse import urljoin
 
 from chronam.core import index, models
 from chronam.core.decorator import add_cache_headers, cors, rdf_view
@@ -226,7 +226,7 @@ def issue_pages_rdf(request, lccn, date, edition):
 def page_words(request, lccn, date, edition, sequence, words=None):
     """
     for the case where we have ;words= in the url convert it to a fragment but
-    keep everything else the same so we don't mess up campain codes
+    keep everything else the same so we don't mess up campaign codes
 
     example:
     /lccn/sn83045396/1911-09-17/ed-1/seq-12/;words=foo?bar=ham
@@ -531,14 +531,14 @@ def _search_engine_words(request):
     request didn't come via a search engine result an empty list is
     returned.
     """
-    # get the refering url
+    # get the referring url
     referer = request.META.get("HTTP_REFERER")
     if not referer:
         return []
     uri = urlparse.urlparse(referer)
     qs = urlparse.parse_qs(uri.query)
 
-    # extract a potential search query from refering url
+    # extract a potential search query from referring url
     if "q" in qs:
         words = qs["q"][0]
     elif "p" in qs:

--- a/settings_test.py
+++ b/settings_test.py
@@ -2,18 +2,19 @@ import os
 
 # DO NOT CHECK-IN WORLDCAT_KEY TO REPO
 from settings import WORLDCAT_KEY  # NOQA
+
 from settings_template import *  # NOQA
 from settings_template import DIRNAME, STORAGE
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'TEST': {'CHARSET': "utf8", 'COLLATION': "utf8_general_ci"},
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "TEST": {"CHARSET": "utf8", "COLLATION": "utf8_general_ci"},
     }
 }
 
 CTS_URL = "https://transferqa.loctest.gov/transfer/"
-# Use different storage pathes to avoid interference with the actual storage for the web app
+# Use different storage paths to avoid interference with the actual storage for the web app
 # some tests purge batch and deletes data (such as word coordinates)
 BIB_STORAGE = os.path.join(STORAGE, "test_bib")
 OCR_DUMP_STORAGE = os.path.join(STORAGE, "test_ocr")


### PR DESCRIPTION
`codespell --ignore-words-list=ore -w **/*.py`