### PR TITLE
Update worldcat api deprecated urls (#1)

### DIFF
--- a/core/title_pull.py
+++ b/core/title_pull.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from django.conf import settings
-from worldcat.request.search import SRURequest
+from chronam.core.worldcat_overrides.request import SRURequestV2 as SRURequest
 from worldcat.util.extract import extract_elements
 
 LOGGER = logging.getLogger(__name__)

--- a/core/worldcat_overrides/request.py
+++ b/core/worldcat_overrides/request.py
@@ -1,0 +1,59 @@
+import urllib2
+import urllib
+from exceptions import StopIteration
+
+from worldcat.exceptions import APIKeyError, APIKeyNotSpecifiedError, \
+                                EmptyQueryError, EmptyRecordNumberError, \
+                                InvalidArgumentError, ExtractError
+from worldcat.request.search import SearchAPIRequest
+from worldcat.util.extract import extract_elements
+
+
+# SRURequestV2 class was created to replace the existing SRURequest class in WorldCat that has an incorrect API URL which is causing 
+# breakage with our pull_titles.py script.  This class is a copy of the existing SRURequest class with the exception of the api_url()
+# method which has been updated to use the correct API URL.  This class should be removed once the WorldCat API is fixed.
+# http_get is also overidden to include User-Agent in request to prevent OCLC API from missclassifying our requests as spam.
+class SRURequestV2(SearchAPIRequest):
+    """request.search.NewSRURequest: queries search API using SRU
+    SRURequests should be used when fielded searching is desired.
+    """
+
+    def __init__(self, **kwargs):
+        """Constructor method for WorldCatRequests."""
+        SearchAPIRequest.__init__(self, **kwargs)
+
+    def __iter__(self):
+        return self
+
+    def api_url(self):
+        # Updated URL to use the correct API URL
+        self.url = 'http://worldcat.org/webservices/catalog/search/worldcat/sru'
+
+    def next(self):
+        _i = extract_elements(self.response,
+                element='{http://www.loc.gov/zing/srw/}nextRecordPosition')
+        if len(_i) != 0:
+            if _i[0].text is not None:
+                self.args['startRecord'] = int(_i[0].text)
+            else:
+                raise StopIteration
+        else:
+            raise StopIteration
+
+    def subclass_validator(self, quiet=False):
+        """Validator method for SRURequests."""
+        if 'query' not in self.args:
+            if quiet == True:
+                return False
+            else:
+                raise EmptyQueryError
+        else:
+            return True
+
+    def http_get(self):
+        """HTTP Get method for all WorldCatRequests."""
+        self.api_url()
+        _query_url = '%s?%s' % (self.url, urllib.urlencode(self.args))
+        # Added User-Agent to request to prevent OCLC API from missclassifying our requests as spam.
+        request = urllib2.Request(_query_url, headers={'User-Agent' : "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:10.0.2)"})
+        self.response = urllib2.urlopen(request).read()

--- a/core/worldcat_overrides/request.py
+++ b/core/worldcat_overrides/request.py
@@ -1,59 +1,21 @@
 import urllib2
 import urllib
-from exceptions import StopIteration
 
-from worldcat.exceptions import APIKeyError, APIKeyNotSpecifiedError, \
-                                EmptyQueryError, EmptyRecordNumberError, \
-                                InvalidArgumentError, ExtractError
-from worldcat.request.search import SearchAPIRequest
-from worldcat.util.extract import extract_elements
-
+from worldcat.request.search import SRURequest
 
 # SRURequestV2 class was created to replace the existing SRURequest class in WorldCat that has an incorrect API URL which is causing 
 # breakage with our pull_titles.py script.  This class is a copy of the existing SRURequest class with the exception of the api_url()
 # method which has been updated to use the correct API URL.  This class should be removed once the WorldCat API is fixed.
 # http_get is also overidden to include User-Agent in request to prevent OCLC API from missclassifying our requests as spam.
-class SRURequestV2(SearchAPIRequest):
-    """request.search.NewSRURequest: queries search API using SRU
-    SRURequests should be used when fielded searching is desired.
-    """
-
-    def __init__(self, **kwargs):
-        """Constructor method for WorldCatRequests."""
-        SearchAPIRequest.__init__(self, **kwargs)
-
-    def __iter__(self):
-        return self
-
+class SRURequestV2(SRURequest):
     def api_url(self):
         # Updated URL to use the correct API URL
-        self.url = 'http://worldcat.org/webservices/catalog/search/worldcat/sru'
-
-    def next(self):
-        _i = extract_elements(self.response,
-                element='{http://www.loc.gov/zing/srw/}nextRecordPosition')
-        if len(_i) != 0:
-            if _i[0].text is not None:
-                self.args['startRecord'] = int(_i[0].text)
-            else:
-                raise StopIteration
-        else:
-            raise StopIteration
-
-    def subclass_validator(self, quiet=False):
-        """Validator method for SRURequests."""
-        if 'query' not in self.args:
-            if quiet == True:
-                return False
-            else:
-                raise EmptyQueryError
-        else:
-            return True
+        self.url = 'https://worldcat.org/webservices/catalog/search/worldcat/sru'
 
     def http_get(self):
         """HTTP Get method for all WorldCatRequests."""
         self.api_url()
         _query_url = '%s?%s' % (self.url, urllib.urlencode(self.args))
         # Added User-Agent to request to prevent OCLC API from missclassifying our requests as spam.
-        request = urllib2.Request(_query_url, headers={'User-Agent' : "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:10.0.2)"})
+        request = urllib2.Request(_query_url, headers={'User-Agent' : "ChroniclingAmerica +https://github.com/LibraryOfCongress/chronam"})
         self.response = urllib2.urlopen(request).read()


### PR DESCRIPTION
* Added subclass for SearchAPI Request that allows Chronam to pull titles from updated Worldcat SRU search URL

Pull_Titles script was erroring because OCLC changed the worldcat API search URL to http://worldcat.org/webservices/catalog/search/worldcat/sru when it used to be http://worldcat.org/webservices/catalog/search/sru. 

The WorldCat package (https://github.com/anarchivist/worldcat) that Chronam relies on doesn't have the updated API URL yet; Therefore, I simply subclassed the SearchAPIRequest from WorldCat package on PYPI, updated the URL, and replaced the WorldCat SRURequest in title_pull with the new subclass.

@acdha please let me know of any requests for modification.